### PR TITLE
DL-2269b refactor to fix GG routing issue plus tidy

### DIFF
--- a/test/controllers/ExistingReturnQuestionControllerSpec.scala
+++ b/test/controllers/ExistingReturnQuestionControllerSpec.scala
@@ -177,7 +177,7 @@ val returnTypeCharge: String = "CR"
 
   def getWithUnAuthorisedUser(test: Future[Result] => Any) {
     val userId = s"user-${UUID.randomUUID}"
-        val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
+    val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
     setInvalidAuthMocks(authMock)
     val result = TestExistingReturnQuestionController.view(periodKey, returnTypeCharge).apply(SessionBuilder.buildRequestWithSession(userId))
     test(result)

--- a/test/controllers/PeriodSummaryControllerSpec.scala
+++ b/test/controllers/PeriodSummaryControllerSpec.scala
@@ -180,7 +180,7 @@ class PeriodSummaryControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
 
   def getWithUnAuthorisedUser(test: Future[Result] => Any) {
     val userId = s"user-${UUID.randomUUID}"
-        val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
+    val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
     setInvalidAuthMocks(authMock)
     val result = TestPeriodSummaryController.view(periodKey).apply(SessionBuilder.buildRequestWithSession(userId))
     test(result)

--- a/test/controllers/propertyDetails/AddressLookupControllerSpec.scala
+++ b/test/controllers/propertyDetails/AddressLookupControllerSpec.scala
@@ -275,7 +275,7 @@ class AddressLookupControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
 
   def viewWithUnAuthorisedUser(test: Future[Result] => Any) {
     val userId = s"user-${UUID.randomUUID}"
-        val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
+    val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
     setInvalidAuthMocks(authMock)
     when(mockDataCacheConnector.fetchAtedRefData[String](Matchers.eq(AtedConstants.DelegatedClientAtedRefNumber))
       (Matchers.any(), Matchers.any(), Matchers.any())).thenReturn(Future.successful(Some("XN1200000100001")))
@@ -297,7 +297,7 @@ class AddressLookupControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
 
   def findWithUnAuthorisedUser(test: Future[Result] => Any) {
     val userId = s"user-${UUID.randomUUID}"
-        val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
+    val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
     setInvalidAuthMocks(authMock)
     when(mockDataCacheConnector.fetchAtedRefData[String](Matchers.eq(AtedConstants.DelegatedClientAtedRefNumber))
       (Matchers.any(), Matchers.any(), Matchers.any())).thenReturn(Future.successful(Some("XN1200000100001")))
@@ -318,7 +318,7 @@ class AddressLookupControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
 
   def saveWithUnAuthorisedUser(test: Future[Result] => Any) {
     val userId = s"user-${UUID.randomUUID}"
-        val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
+    val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
     setInvalidAuthMocks(authMock)
     when(mockDataCacheConnector.fetchAtedRefData[String](Matchers.eq(AtedConstants.DelegatedClientAtedRefNumber))
       (Matchers.any(), Matchers.any(), Matchers.any())).thenReturn(Future.successful(Some("XN1200000100001")))

--- a/test/controllers/propertyDetails/IsFullTaxPeriodControllerSpec.scala
+++ b/test/controllers/propertyDetails/IsFullTaxPeriodControllerSpec.scala
@@ -197,7 +197,7 @@ class IsFullTaxPeriodControllerSpec extends PlaySpec with GuiceOneServerPerSuite
 
   def getWithUnAuthorisedUser(test: Future[Result] => Any) {
     val userId = s"user-${UUID.randomUUID}"
-        val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
+    val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
     setInvalidAuthMocks(authMock)
     when(mockDataCacheConnector.fetchAtedRefData[String](Matchers.eq(AtedConstants.DelegatedClientAtedRefNumber))
       (Matchers.any(), Matchers.any(), Matchers.any())).thenReturn(Future.successful(Some("XN1200000100001")))

--- a/test/controllers/propertyDetails/PeriodChooseReliefsControllerSpec.scala
+++ b/test/controllers/propertyDetails/PeriodChooseReliefsControllerSpec.scala
@@ -159,7 +159,7 @@ class PeriodChooseReliefsControllerSpec extends PlaySpec with GuiceOneServerPerS
 
   def saveWithUnAuthorisedUser(test: Future[Result] => Any) {
     val userId = s"user-${UUID.randomUUID}"
-        val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
+    val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
     setInvalidAuthMocks(authMock)
     val result = TestPropertyDetailsPeriodController.save("1", periodKey).apply(SessionBuilder.buildRequestWithSession(userId))
     test(result)

--- a/test/controllers/propertyDetails/PeriodDatesLiableControllerSpec.scala
+++ b/test/controllers/propertyDetails/PeriodDatesLiableControllerSpec.scala
@@ -199,7 +199,7 @@ class PeriodDatesLiableControllerSpec extends PlaySpec with GuiceOneServerPerSui
 
   def getWithUnAuthorisedUser(test: Future[Result] => Any) {
     val userId = s"user-${UUID.randomUUID}"
-        val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
+    val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
     setInvalidAuthMocks(authMock)
     when(mockBackLinkCache.fetchAndGetBackLink(Matchers.any())(Matchers.any())).thenReturn(Future.successful(None))
     val result = TestPropertyDetailsPeriodController.view("1").apply(SessionBuilder.buildRequestWithSession(userId))
@@ -233,7 +233,7 @@ class PeriodDatesLiableControllerSpec extends PlaySpec with GuiceOneServerPerSui
   def saveWithUnAuthorisedUser(test: Future[Result] => Any) {
     val periodKey: Int = 2015
     val userId = s"user-${UUID.randomUUID}"
-        val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
+    val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
     setInvalidAuthMocks(authMock)
     val result = TestPropertyDetailsPeriodController.save("1", periodKey).apply(SessionBuilder.buildRequestWithSession(userId))
     test(result)

--- a/test/controllers/propertyDetails/PropertyDetailsAddressControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsAddressControllerSpec.scala
@@ -226,7 +226,7 @@ class PropertyDetailsAddressControllerSpec extends PlaySpec with GuiceOneServerP
 
   def createWithUnAuthorisedUser(test: Future[Result] => Any) {
     val userId = s"user-${UUID.randomUUID}"
-        val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
+    val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
     setInvalidAuthMocks(authMock)
     val result = TestPropertyDetailsController.createNewDraft(periodKey).apply(SessionBuilder.buildRequestWithSession(userId))
     test(result)
@@ -296,7 +296,7 @@ class PropertyDetailsAddressControllerSpec extends PlaySpec with GuiceOneServerP
 
   def saveWithUnAuthorisedUser(id: Option[String])(test: Future[Result] => Any) {
     val userId = s"user-${UUID.randomUUID}"
-        val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
+    val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
     setInvalidAuthMocks(authMock)
     val result = TestPropertyDetailsController.save(id, periodKey, None).apply(SessionBuilder.buildRequestWithSession(userId))
     test(result)

--- a/test/controllers/propertyDetails/PropertyDetailsDeclarationControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsDeclarationControllerSpec.scala
@@ -159,7 +159,7 @@ class PropertyDetailsDeclarationControllerSpec extends PlaySpec with GuiceOneSer
 
   def getWithUnAuthorisedUser(test: Future[Result] => Any): Unit = {
     val userId = s"user-${UUID.randomUUID}"
-        val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
+    val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
     setInvalidAuthMocks(authMock)
     val result = TestPropertyDetailsDeclarationController.view("1").apply(SessionBuilder.buildRequestWithSession(userId))
     test(result)

--- a/test/controllers/propertyDetails/PropertyDetailsInReliefControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsInReliefControllerSpec.scala
@@ -172,7 +172,7 @@ class PropertyDetailsInReliefControllerSpec extends PlaySpec with GuiceOneServer
 
   def getWithUnAuthorisedUser(test: Future[Result] => Any) {
     val userId = s"user-${UUID.randomUUID}"
-        val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
+    val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
     setInvalidAuthMocks(authMock)
     val result = TestPropertyDetailsPeriodController.view("1").apply(SessionBuilder.buildRequestWithSession(userId))
     test(result)
@@ -204,7 +204,7 @@ class PropertyDetailsInReliefControllerSpec extends PlaySpec with GuiceOneServer
 
   def saveWithUnAuthorisedUser(test: Future[Result] => Any) {
     val userId = s"user-${UUID.randomUUID}"
-        val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
+    val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
     setInvalidAuthMocks(authMock)
     val result = TestPropertyDetailsPeriodController.save("1", periodKey, None).apply(SessionBuilder.buildRequestWithSession(userId))
     test(result)

--- a/test/controllers/propertyDetails/PropertyDetailsOwnedBeforeControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsOwnedBeforeControllerSpec.scala
@@ -170,7 +170,7 @@ class PropertyDetailsOwnedBeforeControllerSpec extends PlaySpec with GuiceOneSer
 
   def getWithUnAuthorisedUser(test: Future[Result] => Any) {
     val userId = s"user-${UUID.randomUUID}"
-        val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
+    val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
     setInvalidAuthMocks(authMock)
     val result = TestPropertyDetailsController.view("1").apply(SessionBuilder.buildRequestWithSession(userId))
     test(result)
@@ -206,7 +206,7 @@ class PropertyDetailsOwnedBeforeControllerSpec extends PlaySpec with GuiceOneSer
   def saveWithUnAuthorisedUser(test: Future[Result] => Any) {
     val periodKey: Int = 2015
     val userId = s"user-${UUID.randomUUID}"
-        val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
+    val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
     setInvalidAuthMocks(authMock)
     val result = TestPropertyDetailsController.save("1", periodKey, None).apply(SessionBuilder.buildRequestWithSession(userId))
     test(result)

--- a/test/controllers/propertyDetails/PropertyDetailsSupportingInfoControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsSupportingInfoControllerSpec.scala
@@ -254,7 +254,7 @@ class PropertyDetailsSupportingInfoControllerSpec extends PlaySpec with GuiceOne
   def saveWithUnAuthorisedUser(test: Future[Result] => Any) {
     val periodKey: Int = 2015
     val userId = s"user-${UUID.randomUUID}"
-        val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
+    val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
     setInvalidAuthMocks(authMock)
     val result = TestPropertyDetailsPeriodController.save("1", periodKey, None).apply(SessionBuilder.buildRequestWithSession(userId))
     test(result)

--- a/test/controllers/propertyDetails/PropertyDetailsTaxAvoidanceControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsTaxAvoidanceControllerSpec.scala
@@ -206,7 +206,7 @@ class PropertyDetailsTaxAvoidanceControllerSpec extends PlaySpec with GuiceOneSe
 
   def getWithUnAuthorisedUser(test: Future[Result] => Any) {
     val userId = s"user-${UUID.randomUUID}"
-        val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
+    val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
     setInvalidAuthMocks(authMock)
     val result = TestPropertyDetailsPeriodController.view("1").apply(SessionBuilder.buildRequestWithSession(userId))
     test(result)
@@ -242,7 +242,7 @@ class PropertyDetailsTaxAvoidanceControllerSpec extends PlaySpec with GuiceOneSe
   def saveWithUnAuthorisedUser(test: Future[Result] => Any) {
     val periodKey: Int = 2015
     val userId = s"user-${UUID.randomUUID}"
-        val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
+    val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
     setInvalidAuthMocks(authMock)
     val result = TestPropertyDetailsPeriodController.save("1", periodKey, None).apply(SessionBuilder.buildRequestWithSession(userId))
     test(result)

--- a/test/utils/MockAuthUtil.scala
+++ b/test/utils/MockAuthUtil.scala
@@ -77,7 +77,7 @@ trait MockAuthUtil extends MockitoSugar with TestUtil {
     when(mockDelegationService.delegationCall(Matchers.any())(Matchers.any())).thenReturn(Future.successful(Some(delegationModel)))
     when(mockAuthConnector.authorise[Enrolments ~ Some[AffinityGroup] ~ Some[String]]
       (Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any()))
-      .thenReturn(Future.failed(MissingBearerToken("Auth Error")))
+      .thenReturn(Future.failed(InsufficientEnrolments("Auth Error")))
   }
 
   def setForbiddenAuthMocks(


### PR DESCRIPTION
DL-2269b - refactor to address gateway redirect issue identified in QA

**Bug fix** (delete as appropriate)

Refactoring Auth and AuthSpec to rectify behaviour on new Auth which did not reflect the current behaviour prior to the upgrade. Rerouting to Gateway login now occurs for NoActiveSession.

## Checklist

*Reviewee* (Replace with your name)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date