### PR TITLE
DL-2435 Fixed invalid dates on unused reliefs being validated

### DIFF
--- a/app/utils/ReliefsUtils.scala
+++ b/app/utils/ReliefsUtils.scala
@@ -17,9 +17,12 @@
 package utils
 
 import models._
+import play.api.Logger
 import play.api.Play.current
 import play.api.i18n.Messages
 import play.api.i18n.Messages.Implicits._
+
+import scala.collection.immutable
 
 object ReliefsUtils extends ReliefConstants {
 
@@ -59,6 +62,35 @@ object ReliefsUtils extends ReliefConstants {
       EquityReleaseDesc -> "ated.choose-reliefs.equityRelease"
     )
     reliefsDescription.getOrElse(etmpReliefName, etmpReliefName)
+  }
+
+  private[utils] val dataCleanseMap = Map(
+    "rentalBusinessDate"      -> "rentalBusiness",
+    "openToPublicDate"        -> "openToPublic",
+    "propertyDeveloperDate"   -> "propertyDeveloper",
+    "propertyTradingDate"     -> "propertyTrading",
+    "lendingDate"             -> "lending",
+    "employeeOccupationDate"  -> "employeeOccupation",
+    "farmHousesDate"          -> "farmHouses",
+    "socialHousingDate"       -> "socialHousing",
+    "equityReleaseDate"       -> "equityRelease"
+  )
+
+  def cleanDateTuples(data: Map[String, Seq[String]]): Map[String, Seq[String]] = {
+    val keysToKeep: List[String] = data.flatMap { case (key, entry) =>
+      entry.headOption
+        .filter(_ == "true")
+        .map(_ => key)
+    }.toList
+
+    data.filter { case (key, _) =>
+      val takeWhileKey: String = key.takeWhile(_ != '.')
+
+      dataCleanseMap.get(takeWhileKey) match {
+        case Some(dateField)  => keysToKeep.contains(dateField)
+        case _                => true
+      }
+    }
   }
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,13 +4,13 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.16.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.2.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.19.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.0.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.6.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.19.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.0.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.23")
 

--- a/test/controllers/reliefs/ChooseReliefsControllerSpec.scala
+++ b/test/controllers/reliefs/ChooseReliefsControllerSpec.scala
@@ -58,9 +58,9 @@ class ChooseReliefsControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
   val reliefsTaxAvoid: ReliefsTaxAvoidance = ReliefBuilder.reliefTaxAvoidance(periodKey,
     Reliefs(periodKey = periodKey, rentalBusiness = true, isAvoidanceScheme = None))
   val testReliefs: ReliefsTaxAvoidance =
-    ReliefBuilder.reliefTaxAvoidance(periodKey,Reliefs(periodKey = periodKey, rentalBusiness = true, isAvoidanceScheme = Some(false)))
+    ReliefBuilder.reliefTaxAvoidance(periodKey, Reliefs(periodKey = periodKey, rentalBusiness = true, isAvoidanceScheme = Some(false)))
   val testReliefsWithTaxAvoidance: ReliefsTaxAvoidance =
-    ReliefBuilder.reliefTaxAvoidance(periodKey,Reliefs(periodKey = periodKey, rentalBusiness = true, isAvoidanceScheme = Some(true)))
+    ReliefBuilder.reliefTaxAvoidance(periodKey, Reliefs(periodKey = periodKey, rentalBusiness = true, isAvoidanceScheme = Some(true)))
   val testReliefsWithTaxAvoidancePopulated: ReliefsTaxAvoidance = ReliefBuilder.reliefTaxAvoidance(periodKey,
     Reliefs(periodKey = periodKey, rentalBusiness = true, isAvoidanceScheme = Some(true)),
     TaxAvoidance(rentalBusinessScheme = Some("avoid1"))
@@ -97,7 +97,7 @@ class ChooseReliefsControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
       test(result)
     }
 
-    def editFromSummary(reliefs: Option[ReliefsTaxAvoidance]= None)(test: Future[Result] => Any) {
+    def editFromSummary(reliefs: Option[ReliefsTaxAvoidance] = None)(test: Future[Result] => Any) {
       val userId = s"user-${UUID.randomUUID}"
       val authMock = authResultDefault(AffinityGroup.Organisation, defaultEnrolmentSet)
       setAuthMocks(authMock)
@@ -109,7 +109,7 @@ class ChooseReliefsControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
       test(result)
     }
 
-    def forbiddenEditFromSummary(reliefs: Option[ReliefsTaxAvoidance]= None)(test: Future[Result] => Any) {
+    def forbiddenEditFromSummary(reliefs: Option[ReliefsTaxAvoidance] = None)(test: Future[Result] => Any) {
       val userId = s"user-${UUID.randomUUID}"
       val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
       setForbiddenAuthMocks(authMock)
@@ -209,16 +209,16 @@ class ChooseReliefsControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
 
       "Authorised users" must {
 
-          "return a status of OK && Choose reliefs page be displayed empty v2.0" in new Setup {
-            getAuthorisedUserNone {
-              result =>
-                status(result) must be(OK)
-                val document = Jsoup.parse(contentAsString(result))
-                document.getElementById("lede-text")
-                  .text() must be("You can select more than one relief code. A single relief code can cover one or more properties.")
+        "return a status of OK && Choose reliefs page be displayed empty v2.0" in new Setup {
+          getAuthorisedUserNone {
+            result =>
+              status(result) must be(OK)
+              val document = Jsoup.parse(contentAsString(result))
+              document.getElementById("lede-text")
+                .text() must be("You can select more than one relief code. A single relief code can cover one or more properties.")
 
-            }
           }
+        }
 
         "return a status of redirect && Choose reliefs page be displayed filled form, if something has been saved earlier" in new Setup {
           getAuthorisedUserSome {
@@ -313,7 +313,7 @@ class ChooseReliefsControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         }
 
         "for invalid data, return BAD_REQUEST" in new Setup {
-          val inputJson: JsValue = Json.parse( """{"periodKey": 2015, "rentalBusiness": false, "isAvoidanceScheme": ""}""")
+          val inputJson: JsValue = Json.parse("""{"periodKey": 2015, "rentalBusiness": false, "isAvoidanceScheme": ""}""")
           when(mockBackLinkCacheConnector.fetchAndGetBackLink(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
           submitWithAuthorisedUser(FakeRequest().withFormUrlEncodedBody(), inputJson) {
             result =>
@@ -322,7 +322,7 @@ class ChooseReliefsControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         }
 
         "for invalid data, return BAD_REQUEST v2.0" in new Setup {
-          val inputJson: JsValue = Json.parse( """{"periodKey": 2015, "rentalBusiness": false, "isAvoidanceScheme": ""}""")
+          val inputJson: JsValue = Json.parse("""{"periodKey": 2015, "rentalBusiness": false, "isAvoidanceScheme": ""}""")
           when(mockBackLinkCacheConnector.fetchAndGetBackLink(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
           submitWithAuthorisedUser(FakeRequest().withFormUrlEncodedBody(), inputJson) {
             result =>
@@ -331,61 +331,93 @@ class ChooseReliefsControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         }
 
         "for respective relief selected, respective dates become mandatory, so give BAD_REQUEST" in new Setup {
-            val reliefs = Reliefs(periodKey = periodKey, rentalBusiness = true, openToPublic = true, propertyDeveloper = true)
-            val json: JsValue = Json.toJson(reliefs)
-            when(mockBackLinkCacheConnector.fetchAndGetBackLink(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-            submitWithAuthorisedUser(FakeRequest().withFormUrlEncodedBody(), json) {
-              result =>
-                status(result) must be(BAD_REQUEST)
-                contentAsString(result) must include("There is a problem with the page")
-            }
-          }
-
-          "for all/any dates too early than period, return BAD_REQUEST" in new Setup {
-            val inputJsonOne: JsValue = Json.parse(
-              """{"periodKey": 2015,
-                |"rentalBusiness": true,
-                |"rentalBusinessDate.year": "2014",
-                |"rentalBusinessDate.month": "05",
-                |"rentalBusinessDate.day": "01",
-                |"isAvoidanceScheme": true }""".stripMargin)
-            when(mockBackLinkCacheConnector.fetchAndGetBackLink(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-            submitWithAuthorisedUser(FakeRequest().withFormUrlEncodedBody(), inputJsonOne) {
-              result =>
-                status(result) must be(BAD_REQUEST)
-                contentAsString(result) must include("There is a problem with the page")
-            }
-          }
-          "for all/any dates too late than period, return BAD_REQUEST" in new Setup {
-            val inputJsonOne: JsValue = Json.parse(
-              """{"periodKey": 2015,
-                |"rentalBusiness": true,
-                |"rentalBusinessDate.year": "2016",
-                |"rentalBusinessDate.month": "05",
-                |"rentalBusinessDate.day": "01",
-                |"isAvoidanceScheme": true }""".stripMargin)
-            when(mockBackLinkCacheConnector.fetchAndGetBackLink(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-            submitWithAuthorisedUser(FakeRequest().withFormUrlEncodedBody(), inputJsonOne) {
-              result =>
-                status(result) must be(BAD_REQUEST)
-                contentAsString(result) must include("There is a problem with the page")
-            }
-          }
-          "for valid data, return OK" in new Setup {
-            val formBody = List(
-              ("periodKey", "2015"),
-              ("rentalBusiness", "true"),
-              ("isAvoidanceScheme", "true"),
-              ("rentalBusinessDate.year", "2015"),
-              ("rentalBusinessDate.month", "05"),
-              ("rentalBusinessDate.day", "01"))
-            when(mockBackLinkCacheConnector.saveBackLink(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-            submitFormBodyWithAuthorisedUser(FakeRequest().withFormUrlEncodedBody(formBody: _*)) {
-              result =>
-                status(result) must be(SEE_OTHER)
-            }
+          val reliefs = Reliefs(periodKey = periodKey, rentalBusiness = true, openToPublic = true, propertyDeveloper = true)
+          val json: JsValue = Json.toJson(reliefs)
+          when(mockBackLinkCacheConnector.fetchAndGetBackLink(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
+          submitWithAuthorisedUser(FakeRequest().withFormUrlEncodedBody(), json) {
+            result =>
+              status(result) must be(BAD_REQUEST)
+              contentAsString(result) must include("There is a problem with the page")
           }
         }
+
+        "for all/any dates too early than period, return BAD_REQUEST" in new Setup {
+          val inputJsonOne: JsValue = Json.parse(
+            """{"periodKey": 2015,
+              |"rentalBusiness": true,
+              |"rentalBusinessDate.year": "2014",
+              |"rentalBusinessDate.month": "05",
+              |"rentalBusinessDate.day": "01",
+              |"isAvoidanceScheme": true }""".stripMargin)
+          when(mockBackLinkCacheConnector.fetchAndGetBackLink(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
+          submitWithAuthorisedUser(FakeRequest().withFormUrlEncodedBody(), inputJsonOne) {
+            result =>
+              status(result) must be(BAD_REQUEST)
+              contentAsString(result) must include("There is a problem with the page")
+          }
+        }
+        "for all/any dates too late than period, return BAD_REQUEST" in new Setup {
+          val inputJsonOne: JsValue = Json.parse(
+            """{"periodKey": 2015,
+              |"rentalBusiness": true,
+              |"rentalBusinessDate.year": "2016",
+              |"rentalBusinessDate.month": "05",
+              |"rentalBusinessDate.day": "01",
+              |"isAvoidanceScheme": true }""".stripMargin)
+          when(mockBackLinkCacheConnector.fetchAndGetBackLink(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
+          submitWithAuthorisedUser(FakeRequest().withFormUrlEncodedBody(), inputJsonOne) {
+            result =>
+              status(result) must be(BAD_REQUEST)
+              contentAsString(result) must include("There is a problem with the page")
+          }
+        }
+        "for all/any dates which are invalid, return BAD_REQUEST" in new Setup {
+          val inputJsonOne: JsValue = Json.parse(
+            """{"periodKey": 2015,
+              |"rentalBusiness": true,
+              |"rentalBusinessDate.year": "2016",
+              |"rentalBusinessDate.month": "02",
+              |"rentalBusinessDate.day": "31",
+              |"isAvoidanceScheme": true }""".stripMargin)
+          when(mockBackLinkCacheConnector.fetchAndGetBackLink(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
+          submitWithAuthorisedUser(FakeRequest().withFormUrlEncodedBody(), inputJsonOne) {
+            result =>
+              status(result) must be(BAD_REQUEST)
+              contentAsString(result) must include("There is a problem with the page")
+          }
+        }
+        "for one date that is invalid but unselected, with valid data, return OK" in new Setup {
+          val formBody = List(
+            ("periodKey", "2015"),
+            ("openToPublicDate.year", "2015"),
+            ("openToPublicDate.month", "02"),
+            ("openToPublicDate.year", "31"),
+            ("rentalBusiness", "true"),
+            ("isAvoidanceScheme", "true"),
+            ("rentalBusinessDate.year", "2015"),
+            ("rentalBusinessDate.month", "05"),
+            ("rentalBusinessDate.day", "01"))
+          when(mockBackLinkCacheConnector.saveBackLink(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
+          submitFormBodyWithAuthorisedUser(FakeRequest().withFormUrlEncodedBody(formBody: _*)) {
+            result =>
+              status(result) must be(SEE_OTHER)
+          }
+        }
+        "for valid data, return OK" in new Setup {
+          val formBody = List(
+            ("periodKey", "2015"),
+            ("rentalBusiness", "true"),
+            ("isAvoidanceScheme", "true"),
+            ("rentalBusinessDate.year", "2015"),
+            ("rentalBusinessDate.month", "05"),
+            ("rentalBusinessDate.day", "01"))
+          when(mockBackLinkCacheConnector.saveBackLink(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
+          submitFormBodyWithAuthorisedUser(FakeRequest().withFormUrlEncodedBody(formBody: _*)) {
+            result =>
+              status(result) must be(SEE_OTHER)
+          }
+        }
+      }
     }
   }
 }

--- a/test/utils/ReliefsUtilsSpec.scala
+++ b/test/utils/ReliefsUtilsSpec.scala
@@ -48,4 +48,26 @@ class ReliefsUtilsSpec extends PlaySpec with GuiceOneServerPerSuite with ReliefC
     }
   }
 
+  "cleanDateTuples" should {
+    "remove date fields where the checkbox is unticked" in {
+      val mapTuple: Map[String, Seq[String]] = ReliefsUtils.dataCleanseMap.keys
+        .toList
+        .zipWithIndex
+        .flatMap {
+          case (key, i) =>
+            val fields = List(key + ".year", key + ".month", key + ".day")
+            if (i % 2 == 0) {
+              fields
+            } else {
+              fields :+ ReliefsUtils.dataCleanseMap(key)
+            }
+        }
+        .map { key => (key, "true") }
+        .toMap
+        .mapValues(str => Seq(str))
+
+      ReliefsUtils.cleanDateTuples(mapTuple).size mustBe 16
+    }
+  }
+
 }


### PR DESCRIPTION
DL-2435 Fixed invalid dates on unused reliefs being validated

**Bug fix**

* Fixed invalid dates pertaining to unselected reliefs on the choose reliefs page causing the page to be unable to submit.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date