### PR TITLE
DL-2607 Prevent tampering to access declaration URL

### DIFF
--- a/app/controllers/propertyDetails/PropertyDetailsDeclarationController.scala
+++ b/app/controllers/propertyDetails/PropertyDetailsDeclarationController.scala
@@ -43,9 +43,12 @@ class PropertyDetailsDeclarationController @Inject()(mcc: MessagesControllerComp
     authAction.authorisedAction { implicit authContext =>
       ensureClientContext {
         propertyDetailsCacheResponse(id) {
-          case PropertyDetailsCacheSuccessResponse(_) =>
+          case PropertyDetailsCacheSuccessResponse(response) =>
             currentBackLink.map(backLink =>
-              Ok(views.html.propertyDetails.propertyDetailsDeclaration(id, backLink))
+              response.calculated match {
+                case Some(_) => Ok(views.html.propertyDetails.propertyDetailsDeclaration(id, backLink))
+                case _       => Redirect(routes.PropertyDetailsSummaryController.view(id))
+              }
             )
         }
       }
@@ -55,13 +58,20 @@ class PropertyDetailsDeclarationController @Inject()(mcc: MessagesControllerComp
   def submit(id: String): Action[AnyContent] = Action.async { implicit request =>
     authAction.authorisedAction { implicit authContext =>
       ensureClientContext {
-        propertyDetailsService.submitDraftPropertyDetails(id) flatMap { response =>
-          response.status match {
-            case OK => Future.successful(Redirect(controllers.propertyDetails.routes.ChargeableReturnConfirmationController.confirmation()))
-            case BAD_REQUEST if response.body.contains("Agent not Valid") =>
-              Future.successful(BadRequest(views.html.global_error("ated.client-problem.title",
-                "ated.client-problem.header", "ated.client-problem.message", Some(appConfig.agentRedirectedToMandate), None, None, appConfig)))
-          }
+        propertyDetailsCacheResponse(id) {
+          case PropertyDetailsCacheSuccessResponse(cacheResponse) =>
+            cacheResponse.calculated match {
+              case Some(_) =>
+                propertyDetailsService.submitDraftPropertyDetails(id) flatMap { response =>
+                  response.status match {
+                    case OK => Future.successful(Redirect(controllers.propertyDetails.routes.ChargeableReturnConfirmationController.confirmation()))
+                    case BAD_REQUEST if response.body.contains("Agent not Valid") =>
+                      Future.successful(BadRequest(views.html.global_error("ated.client-problem.title",
+                        "ated.client-problem.header", "ated.client-problem.message", Some(appConfig.agentRedirectedToMandate), None, None, appConfig)))
+                  }
+                }
+              case _      => Future.successful(Redirect(routes.PropertyDetailsSummaryController.view(id)))
+            }
         }
       }
     }


### PR DESCRIPTION
# DL-2607 Prevent tampering to access declaration URL

**Bug fix**

* Prevented being able to access the declaration page in invalid scenarios.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date