### PR TITLE
DL-2499 Changed 'view' to 'view or change' on period-summary

### DIFF
--- a/app/views/periodSummary.scala.html
+++ b/app/views/periodSummary.scala.html
@@ -103,7 +103,7 @@ periodEndDate(periodKey).toString(Messages("ated.date-format.summary"))), subHea
           <div class="grid grid-1-4 psp-action">
               <a id="relief-submitted-@t._2" href='@controllers.reliefs.routes.ViewReliefReturnController.viewReliefReturn(periodKey, t._1.formBundleNo)'
                  data-journey-click="ated-fronted:click:liability-submitted">
-                @Messages("ated.period-summary.view.button") <span class="visuallyhidden">@Messages("ated.period-summary.sr.return") @t._1.reliefType</span>
+                @Messages("ated.period-summary.view-edit.button") <span class="visuallyhidden">@Messages("ated.period-summary.sr.return") @t._1.reliefType</span>
               </a>
           </div>
         </div>

--- a/test/views/periodSummarySpec.scala
+++ b/test/views/periodSummarySpec.scala
@@ -108,7 +108,7 @@ class periodSummarySpec extends FeatureSpec with GuiceOneAppPerSuite with Mockit
       assert(document.getElementById("view-edit-0").text() === "View or change return, addr1+2")
       assert(document.getElementById("liability-submitted-0").attr("href") === "/ated/form-bundle/123456789013/2015")
 
-      assert(document.getElementById("relief-submitted-0").text() === "View return, some relief")
+      assert(document.getElementById("relief-submitted-0").text() === "View or change return, some relief")
       assert(document.getElementById("draft-liability-0").text() === "View or change return, desc")
       assert(document.getElementById("draft-relief-1").text() === "View or change return, some relief")
 
@@ -136,7 +136,7 @@ class periodSummarySpec extends FeatureSpec with GuiceOneAppPerSuite with Mockit
       assert(document.getElementById("view-edit-0").text() === "View or change return, addr1+2")
       assert(document.getElementById("liability-submitted-0").attr("href") === "/ated/form-bundle/123456789013/2015")
 
-      assert(document.getElementById("relief-submitted-0").text() === "View return, some relief")
+      assert(document.getElementById("relief-submitted-0").text() === "View or change return, some relief")
       assert(document.getElementById("draft-liability-0").text() === "View or change return, desc")
       assert(document.getElementById("draft-relief-1").text() === "View or change return, some relief")
 


### PR DESCRIPTION
# DL-2499 Changed 'view' to 'view or change' on period-summary

**Bug fix**

The only functional change is a simple content change on period-summary. **View** now says **View or change**

## Checklist

*Reviewee* (Chris)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date