### PR TITLE
DL-2592 Added logic for unique addresses

### DIFF
--- a/app/controllers/propertyDetails/SelectExistingReturnAddressController.scala
+++ b/app/controllers/propertyDetails/SelectExistingReturnAddressController.scala
@@ -16,6 +16,8 @@
 
 package controllers.propertyDetails
 
+import java.time.LocalDate
+
 import config.ApplicationConfig
 import connectors.{BackLinkCacheConnector, DataCacheConnector}
 import controllers.auth.{AuthAction, ClientHelper}
@@ -26,6 +28,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.{DelegationService, FormBundleReturnsService, PropertyDetailsService, SummaryReturnsService}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import utils.AtedConstants._
+
 import scala.concurrent.{ExecutionContext, Future}
 
 class SelectExistingReturnAddressController @Inject()(mcc: MessagesControllerComponents,
@@ -51,8 +54,11 @@ class SelectExistingReturnAddressController @Inject()(mcc: MessagesControllerCom
           previousReturns <- summaryReturnService.retrieveCachedPreviousReturnAddressList
         } yield {
           previousReturns match {
-            case Some(pr) => Ok(views.html.propertyDetails.selectPreviousReturn
-            (periodKey, returnType, addressSelectedForm, pr, getBackLink(periodKey, returnType)))
+            case Some(pr) =>
+              val uniqueAddresses = pr.groupBy(_.address).values.map(_.sortWith((a,b) => a.date.isAfter(b.date)).head).toSeq
+
+              Ok(views.html.propertyDetails.selectPreviousReturn
+            (periodKey, returnType, addressSelectedForm, uniqueAddresses, getBackLink(periodKey, returnType)))
             case None => Ok(views.html.propertyDetails.selectPreviousReturn
             (periodKey, returnType, addressSelectedForm, Nil, getBackLink(periodKey, returnType)))
           }

--- a/app/models/AddressLookupModels.scala
+++ b/app/models/AddressLookupModels.scala
@@ -16,9 +16,12 @@
 
 package models
 
+import org.joda.time.LocalDate
+import play.api.libs.json.JodaReads._
+import play.api.libs.json.JodaWrites._
 import play.api.libs.json.{Json, OFormat}
 
-case class PreviousReturns(address: String, formBundleNumber: String)
+case class PreviousReturns(address: String, formBundleNumber: String, date: LocalDate)
 
 object PreviousReturns {
   implicit val formats: OFormat[PreviousReturns] = Json.format[PreviousReturns]

--- a/app/services/SummaryReturnsService.scala
+++ b/app/services/SummaryReturnsService.scala
@@ -99,7 +99,7 @@ class SummaryReturnsService @Inject()(atedConnector: AtedConnector,
     val submittedReturns = periodSummaryReturns.flatMap(x => x.submittedReturns).filter(_.periodKey == selectedPeriodKey - 1)
     val oldLiabilityReturns = submittedReturns.flatMap(x => x.oldLiabilityReturns)
     val newLiabilityReturns = submittedReturns.flatMap(x => x.currentLiabilityReturns)
-    val pastReturnDetails = (oldLiabilityReturns ++ newLiabilityReturns) map (r => PreviousReturns(r.description, r.formBundleNo))
+    val pastReturnDetails = (oldLiabilityReturns ++ newLiabilityReturns) map (r => PreviousReturns(r.description, r.formBundleNo, r.dateOfSubmission))
     savePastReturnDetails(pastReturnDetails)
   }
 

--- a/test/controllers/ReturnTypeControllerSpec.scala
+++ b/test/controllers/ReturnTypeControllerSpec.scala
@@ -26,6 +26,7 @@ import controllers.propertyDetails.{AddressLookupController, PropertyDetailsAddr
 import controllers.reliefs.ChooseReliefsController
 import testhelpers.MockAuthUtil
 import models.{PreviousReturns, ReturnType}
+import org.joda.time.LocalDate
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
@@ -171,7 +172,7 @@ class ReturnTypeControllerSpec extends PlaySpec with GuiceOneServerPerSuite with
 
     "submit" must {
       "for authorised user" must {
-        val prevReturns = Seq(PreviousReturns("1, addressLine1", "12345678"))
+        val prevReturns = Seq(PreviousReturns("1, addressLine1", "12345678",  new LocalDate("2015-04-02")))
         "with valid form data" must {
           "with invalid form, return BadRequest" in new Setup {
             val inputJson: JsValue = Json.parse( """{"returnType": ""}""")

--- a/test/services/SummaryReturnsServiceSpec.scala
+++ b/test/services/SummaryReturnsServiceSpec.scala
@@ -222,7 +222,7 @@ class SummaryReturnsServiceSpec extends PlaySpec with MockitoSugar with BeforeAn
       val periodSummaryReturns = PeriodSummaryReturns(periodKey, draftReturns = Nil, Some(submittedReturns))
       val data1 = SummaryReturnsModel(Some(BigDecimal(999.99)), Seq(periodSummaryReturns))
       val json1 = Json.toJson(data1)
-      val prevReturn = PreviousReturns("1 address street", "12345678")
+      val prevReturn = PreviousReturns("1 address street", "12345678",  new LocalDate("2015-04-02"))
       val pastReturnDetails = Seq(prevReturn)
 
       "save and return past submitted liabilities for a valid user" in new Setup {
@@ -244,7 +244,7 @@ class SummaryReturnsServiceSpec extends PlaySpec with MockitoSugar with BeforeAn
     }
 
     "retrieveCachedPreviousReturnAddressList" must {
-      val prevReturn = PreviousReturns("1 address street", "12345678")
+      val prevReturn = PreviousReturns("1 address street", "12345678", new LocalDate("2015-04-02"))
       val pastReturnDetails = Some(Seq(prevReturn))
 
       "retrieve cached previous returns address list" in new Setup {


### PR DESCRIPTION
DL-2592 Added logic for unique addresses

**Bug fix** 

On the "/existing-return/select/2017/charge" page duplicate properties were shown because they were being pulled from both the current return and past return section. This bug fix allows for only the latest property to be pulled thereby removing duplicate properties on the page.

## Checklist

Iyke
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date