### PR TITLE
DL-2670: Title key error fix

### DIFF
--- a/app/views/global_error.scala.html
+++ b/app/views/global_error.scala.html
@@ -26,7 +26,6 @@
 @hrefLink = @{href.getOrElse("")}
 @hrefMessages = @{hrefMessage.getOrElse("")}
 @postHref = @{postHrefMessage.getOrElse("")}
- @test = @{Messages(heading)}
 
 
 @contentHeader = {
@@ -37,4 +36,4 @@
  <p class="column-two-thirds">@messages(message)<a href=@messages(hrefLink) target="_blank">@messages(hrefMessages)</a>@messages(postHref)</p>
 }
 
-@global_error_wrapper(appConfig = appConfig, title = pageTitle, contentHeader = Some(contentHeader), mainContent = mainContent)
+@global_error_wrapper(appConfig = appConfig, title = messages(pageTitle), contentHeader = Some(contentHeader), mainContent = mainContent)


### PR DESCRIPTION
# DL-2670 - Error page bug

**Bug fix**
Bug caused by play 2.6 upgrade, missing 'messages' tag to convert key into actual content.

## Checklist
*Reviewee* (Dan)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* Iyke
 - [x]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date