### PR TITLE
DL-2240: Resolve corrupt return state issues

### DIFF
--- a/app/controllers/propertyDetails/IsFullTaxPeriodController.scala
+++ b/app/controllers/propertyDetails/IsFullTaxPeriodController.scala
@@ -51,24 +51,17 @@ class IsFullTaxPeriodController @Inject()(mcc: MessagesControllerComponents,
         propertyDetailsCacheResponse(id) {
           case PropertyDetailsCacheSuccessResponse(propertyDetails) =>
             dataCacheConnector.fetchAndGetFormData[Boolean](SelectedPreviousReturn).flatMap { answer =>
-              if (AtedUtils.isEditSubmitted(propertyDetails) && answer.isEmpty) {
-                forwardBackLinkToNextPage(
-                  propertyDetailsInReliefController.controllerId,
-                  controllers.propertyDetails.routes.PropertyDetailsInReliefController.view(id)
-                )
-              } else {
-                val filledForm = isFullTaxPeriodForm.fill(PropertyDetailsFullTaxPeriod(propertyDetails.period.flatMap(_.isFullPeriod)))
-                currentBackLink.flatMap(backLink =>
-                  answer match {
-                    case Some(true) =>
-                      Future.successful(Ok(views.html.propertyDetails.isFullTaxPeriod(id, propertyDetails.periodKey, isFullTaxPeriodForm,
-                        PeriodUtils.periodStartDate(propertyDetails.periodKey), PeriodUtils.periodEndDate(propertyDetails.periodKey), backLink)))
-                    case _ =>
-                      Future.successful(Ok(views.html.propertyDetails.isFullTaxPeriod(id, propertyDetails.periodKey, filledForm,
-                        PeriodUtils.periodStartDate(propertyDetails.periodKey), PeriodUtils.periodEndDate(propertyDetails.periodKey), backLink)))
-                  }
-                )
-              }
+              val filledForm = isFullTaxPeriodForm.fill(PropertyDetailsFullTaxPeriod(propertyDetails.period.flatMap(_.isFullPeriod)))
+              currentBackLink.flatMap(backLink =>
+                answer match {
+                  case Some(true) =>
+                    Future.successful(Ok(views.html.propertyDetails.isFullTaxPeriod(id, propertyDetails.periodKey, isFullTaxPeriodForm,
+                      PeriodUtils.periodStartDate(propertyDetails.periodKey), PeriodUtils.periodEndDate(propertyDetails.periodKey), backLink)))
+                  case _ =>
+                    Future.successful(Ok(views.html.propertyDetails.isFullTaxPeriod(id, propertyDetails.periodKey, filledForm,
+                      PeriodUtils.periodStartDate(propertyDetails.periodKey), PeriodUtils.periodEndDate(propertyDetails.periodKey), backLink)))
+                }
+              )
             }
         }
       }

--- a/app/services/PropertyDetailsService.scala
+++ b/app/services/PropertyDetailsService.scala
@@ -373,7 +373,7 @@ class PropertyDetailsService @Inject()(propertyDetailsConnector: PropertyDetails
     retrieveDraftPropertyDetails(id).map {
       case PropertyDetailsCacheSuccessResponse(propertDetailsDraft) =>
         propertDetailsDraft.value match {
-          case Some(propVal) =>  propVal.isValuedByAgent.isDefined
+          case Some(propVal) => propVal.isValuedByAgent.isDefined
           case None =>  false
         }
     }

--- a/app/views/editLiability/editLiabilityPrintFriendly.scala.html
+++ b/app/views/editLiability/editLiabilityPrintFriendly.scala.html
@@ -51,11 +51,11 @@
     </tr>
     @for((valueObj, index) <- valuesToDisplay.zipWithIndex) {
     <tr>
-      <td id="property-value-label-@index" class="heading-small">@getPeriodValueMessage(index, valuesToDisplay.size)</td>
+      <td id="property-value-label-@index" class="heading-small">@messages(getPeriodValueMessage(index, valuesToDisplay.size))</td>
       <td id="property-value-value-@index">@formattedPounds(valueObj.propertyValue)</td>
     </tr>
     <tr>
-      <td id="property-date-of-valuation-label-@index" class="heading-small">@getPeriodValueDateMessage(index, valuesToDisplay.size)</td>
+      <td id="property-date-of-valuation-label-@index" class="heading-small">@messages(getPeriodValueDateMessage(index, valuesToDisplay.size))</td>
       <td id="property-date-of-valuation-@index">@valueObj.dateOfChange.toString(messages("ated.date-format"))</td>
     </tr>
     }
@@ -96,7 +96,7 @@
     </tr>
     @for((period, index) <- periods.zipWithIndex) {
     <tr>
-      <td id="return-type-@index" class="td-top heading-small">@period.description</td>
+      <td id="return-type-@index" class="td-top heading-small">@messages(period.description.getOrElse(""))</td>
       <td id="period-@index" class="td-top">@messages("ated.property-details-summary.table.period.text", period.startDate.toString(messages("ated.date-format")), period.endDate.toString(messages("ated.date-format")))</td>
     </tr>
     }

--- a/app/views/propertyDetails/propertyDetailsSummary.scala.html
+++ b/app/views/propertyDetails/propertyDetailsSummary.scala.html
@@ -105,22 +105,6 @@ backLink: Option[String])(implicit authContext: StandardAuthRetrievals, messages
     </div>
   </div>
 
-  <div class="grid-wrapper row-border">
-    <div class="grid grid-2-6 cya-question">
-      <span id="property-date-label" class="heading-small">@messages("ated.form-bundle.view.isValuedByAgent.message")</span>
-    </div>
-
-    <div class="grid grid-1-2 cya-answer">
-      <div id="property-date-of-valuation-incomplete" class="status">@messages("ated.label.incomplete")</div>
-    </div>
-
-    <div class="grid grid-1-6 cya-change">
-      <a href="@controllers.propertyDetails.routes.PropertyDetailsProfessionallyValuedController.view(propertyDetails.id)" id="edit-property-professionally-valued-details-incomplete">
-        @messages("ated.edit") <span class="visuallyhidden">@messages("ated.form-bundle.view.isValuedByAgent.message")</span>
-      </a>
-    </div>
-  </div>
-
   } else {
   @for((valueObj, index) <- valuesToDisplay.zipWithIndex) {
   <div class="grid-wrapper row-border">
@@ -168,6 +152,62 @@ backLink: Option[String])(implicit authContext: StandardAuthRetrievals, messages
   }
   }
 
+<div class="grid-wrapper row-border">
+    <div class="grid grid-2-6 cya-question">
+        <span id="property-date-label" class="heading-small">
+            @messages("ated.form-bundle.view.isValuedByAgent.message")
+        </span>
+    </div>
+
+    @propertyDetails.value.map { propDetailsValue =>
+        @propDetailsValue.isValuedByAgent match {
+            case Some(true) => {
+                <div class="grid grid-1-2 cya-answer">
+                    <div id="property-date-of-valuation">
+                        @messages("ated.property-details-period.yes")
+                    </div>
+                </div>
+                <div class="grid grid-1-6 cya-change">
+                    <a href="@controllers.propertyDetails.routes.PropertyDetailsProfessionallyValuedController.view(propertyDetails.id)" id="edit-property-professionally-valued-details">
+                        @messages("ated.edit")
+                        <span class="visuallyhidden">
+                            @messages("ated.form-bundle.view.isValuedByAgent.message")
+                        </span>
+                    </a>
+                </div>
+            }
+            case Some(false) => {
+                <div class="grid grid-1-2 cya-answer">
+                    <div id="property-date-of-valuation">
+                        @messages("ated.property-details-period.no")
+                    </div>
+                </div>
+                <div class="grid grid-1-6 cya-change">
+                    <a href="@controllers.propertyDetails.routes.PropertyDetailsProfessionallyValuedController.view(propertyDetails.id)" id="edit-property-professionally-valued-details">
+                        @messages("ated.edit")
+                        <span class="visuallyhidden">
+                            @messages("ated.form-bundle.view.isValuedByAgent.message")
+                        </span>
+                    </a>
+                </div>
+            }
+            case None => {
+                <div class="grid grid-1-2 cya-answer">
+                    <div id="property-date-of-valuation-incomplete" class="status">
+                        @messages("ated.label.incomplete")
+                    </div>
+                </div>
+                <div class="grid grid-1-6 cya-change">
+                    <a href="@controllers.propertyDetails.routes.PropertyDetailsProfessionallyValuedController.view(propertyDetails.id)" id="edit-property-professionally-valued-details-incomplete">
+                        @messages("ated.edit")
+                        <span class="visuallyhidden">
+                            @messages("ated.form-bundle.view.isValuedByAgent.message")
+                        </span>
+                    </a>
+                </div>
+            }
+        }
+    }
 </div>
 
 <div class="form-group">
@@ -211,22 +251,6 @@ backLink: Option[String])(implicit authContext: StandardAuthRetrievals, messages
 
 <div class="form-group">
   @propertyDetails.period match {
-    case Some(p) if(p.taxAvoidanceScheme.isEmpty && p.taxAvoidancePromoterReference.isEmpty) => {
-      <div class="grid-wrapper row-border">
-        <div class="grid grid-2-6 cya-question">
-          <h2 id="avoidance-scheme-header-not-provided" class="heading-medium">@messages("ated.property-details-summary.table.property-ated-details.avoidance-scheme.header")</h2>
-        </div>
-
-        <div class="grid grid-1-2 cya-header-ans" id="avoidance-scheme-header-value-not-provided">
-          @messages("ated.property-details-summary.field-blank")
-        </div>
-
-        <div class="grid grid-1-6 cya-header-change">
-          <a href="@controllers.propertyDetails.routes.PropertyDetailsTaxAvoidanceController.editFromSummary(propertyDetails.id)" id="edit-avoidance-scheme-header-not-provided">@messages("ated.edit") <span class="visuallyhidden">@messages("ated.property-details-summary.table.property-ated-details.avoidance-scheme.label")</span>
-          </a>
-        </div>
-      </div>
-    }
     case Some(p) if(p.taxAvoidanceScheme.isDefined && p.taxAvoidancePromoterReference.isDefined) => {
       <div class="grid-wrapper">
         <h2 id="avoidance-scheme-header" class="heading-medium grid grid-1-3">@messages("ated.property-details-summary.table.property-ated-details.avoidance-scheme.header")</h2>
@@ -253,15 +277,32 @@ backLink: Option[String])(implicit authContext: StandardAuthRetrievals, messages
         </div>
       </div>
     }
+    case Some(p) if(p.isTaxAvoidance.isDefined) => {
+      <div class="grid-wrapper row-border">
+        <div class="grid grid-2-6 cya-question">
+          <h2 id="avoidance-scheme-header" class="heading-medium">@messages("ated.property-details-summary.table.property-ated-details.avoidance-scheme.header")</h2>
+        </div>
+
+        <div class="grid grid-1-2 cya-header-ans" id="avoidance-scheme-header-value">
+          <div>@messages("ated.property-details-period.no")</div>
+        </div>
+
+        <div class="grid grid-1-6 cya-header-change">
+          <a href="@controllers.propertyDetails.routes.PropertyDetailsTaxAvoidanceController.editFromSummary(propertyDetails.id)" id="edit-avoidance-scheme-header">@messages("ated.edit") <span class="visuallyhidden">@messages("ated.property-details-summary.table.property-ated-details.avoidance-scheme.label")</span>
+          </a>
+        </div>
+
+      </div>
+    }
     case _ => {
       <div class="grid-wrapper row-border">
         <div class="grid grid-2-6 cya-question">
           <h2 id="avoidance-scheme-header-incomplete" class="heading-medium">@messages("ated.property-details-summary.table.property-ated-details.avoidance-scheme.header")</h2>
         </div>
 
-          <div class="grid grid-1-2 cya-header-ans" id="avoidance-scheme-header-value-incomplete">
-            <div class="status">@incomplete</div>
-          </div>
+        <div class="grid grid-1-2 cya-header-ans" id="avoidance-scheme-header-value-incomplete">
+          <div class="status">@incomplete</div>
+        </div>
 
         <div class="grid grid-1-6 cya-header-change">
           <a href="@controllers.propertyDetails.routes.PropertyDetailsTaxAvoidanceController.editFromSummary(propertyDetails.id)" id="edit-avoidance-scheme-header-incomplete">@messages("ated.edit") <span class="visuallyhidden">@messages("ated.property-details-summary.table.property-ated-details.avoidance-scheme.label")</span>

--- a/app/views/propertyDetails/propertyDetailsSummary.scala.html
+++ b/app/views/propertyDetails/propertyDetailsSummary.scala.html
@@ -100,7 +100,7 @@ backLink: Option[String])(implicit authContext: StandardAuthRetrievals, messages
     </div>
 
     <div class="grid grid-1-6 cya-change">
-      <a href="@controllers.propertyDetails.routes.PropertyDetailsOwnedBeforeController.editFromSummary(propertyDetails.id)" id="edit-property-value-incomplete" data-journey-click="ated-fronted:click:edit-property-value">@messages("ated.edit") <span class="visuallyhidden">@messages("ated.form-bundle.view.return.value.only")</span>
+      <a href="@controllers.editLiability.routes.EditLiabilityHasValueChangedController.view(propertyDetails.id)" id="edit-property-value-incomplete" data-journey-click="ated-fronted:click:edit-property-value">@messages("ated.edit") <span class="visuallyhidden">@messages("ated.form-bundle.view.return.value.only")</span>
       </a>
     </div>
   </div>

--- a/conf/messages
+++ b/conf/messages
@@ -443,7 +443,7 @@ ated.property-details-value.anAcquisition.error-field-name = You must answer thi
 ated.property-details-value.anAcquisition.legend = In this chargeable period, have you bought or sold land, or extended an existing lease on the property, for £40,000 or more?
 ated.property-details-value.anAcquisition.what = Why is the £40,000 level important?
 
-ated.property-details-value.anAcquisition.what.text1 = Buying land or extending an existing lease for £40,000 or more (acquistion) would trigger a revaluation. If the property moves into a higher property band this means you have to pay more tax.
+ated.property-details-value.anAcquisition.what.text1 = Buying land or extending an existing lease for £40,000 or more (acquisition) would trigger a revaluation. If the property moves into a higher property band this means you have to pay more tax.
 ated.property-details-value.anAcquisition.what.text2 = Selling any land connected to the property for £40,000 or more (disposal) would trigger a revaluation. If the property moves into a lower property band this means you have to pay less tax.
 ated.property-details-value.anAcquisition.what.text3 = Further information on this can be found in the <a href="https://www.gov.uk/government/publications/annual-tax-on-enveloped-dwellings-technical-guidance">ATED technical guidance</a>.
 

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -14,13 +14,13 @@ private object AppDependencies {
   val compile = Seq(
     ws,
     "uk.gov.hmrc" %% "bootstrap-play-26" % "1.3.0",
-    "uk.gov.hmrc" %% "auth-client" % "2.32.0-play-26",
-    "uk.gov.hmrc" %% "play-ui" % "8.5.0-play-26",
+    "uk.gov.hmrc" %% "auth-client" % "2.32.1-play-26",
+    "uk.gov.hmrc" %% "play-ui" % "8.6.0-play-26",
     "uk.gov.hmrc" %% "play-partials" % "6.9.0-play-26",
     "uk.gov.hmrc" %% "domain" % "5.6.0-play-26",
     "uk.gov.hmrc" %% "http-caching-client" % "9.0.0-play-26",
     "com.typesafe.play" %% "play-json-joda" % "2.6.10",
-    "uk.gov.hmrc" %% "govuk-template" % "5.44.0-play-26"
+    "uk.gov.hmrc" %% "govuk-template" % "5.48.0-play-26"
   )
 
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.3.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.5.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 

--- a/test/controllers/propertyDetails/IsFullTaxPeriodControllerSpec.scala
+++ b/test/controllers/propertyDetails/IsFullTaxPeriodControllerSpec.scala
@@ -183,7 +183,7 @@ class IsFullTaxPeriodControllerSpec extends PlaySpec with GuiceOneServerPerSuite
 
         getDataWithAuthorisedUser(propertyDetails) {
           result =>
-            status(result) must be(SEE_OTHER)
+            status(result) must be(OK)
         }
       }
 


### PR DESCRIPTION
# DL-2240 - Resolve corrupt return state issues

**Bug fix** 

Users have been seeing system errors when submitting the supporting information for their return. This is because a backend return calculation is triggered on the post of supporting info, even if the user has not provided all of the information required for that calculation to complete successfully. 

To resolve this issue, the user needs to see every page required for their journey, so they have the opportunity to answer the questions required for the calculation. 

The changes of this PR are as follows:-

- ensure the user is able to access the full-tax-period question which the user is currently being diverted away from so are unable to complete all required questions
- take the user to the **Has the value of your property changed for the purposes of ATED?** page from the **edit** link on the summary for **Value for the purposes of ATED** to ensure that question is not missed
- corrected the printed summary to ensure messages are being displayed instead of message keys
- changed the editLiabilitySummary so that the statuses of **Professionally valued** and **Avoidance Scheme** display as Yes, No or INCOMPLETE. Instead of displaying **Not provided** when there is already an answer held.


## Checklist

*David Thornton* 
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [x]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date