### PR TITLE
DL-2333 Amended content for individual auth failure

### DIFF
--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -59,9 +59,10 @@ class ApplicationConfig @Inject()(val conf: ServicesConfig,
   lazy val continueURL: String = s"$loginCallback"
   lazy val signIn: String = s"$companyAuthHost/gg/$loginPath?continue=$loginCallback"
   lazy val signOut: String = s"$companyAuthHost/gg/sign-out"
+  lazy val signOutRedirect: String = conf.getString("microservice.services.auth.sign-out-redirect")
+  lazy val createNewGatewayLink: String = conf.getString("microservice.services.auth.create-account")
   lazy val subscriptionStartPage: String = conf.getString("microservice.services.ated-subscription.serviceRedirectUrl")
   lazy val clientApproveAgentMandate: String = conf.getString("microservice.services.agent-client-mandate-frontend.atedClientApproveAgentUri")
   lazy val agentRedirectedToMandate: String = conf.getString("microservice.services.agent-client-mandate-frontend.atedAgentJourneyStartUri")
-  lazy val businessTaxAccountPage: String = s"${conf.getString("microservice.services.auth.business-tax-account.serviceRedirectUrl")}"
-
+  lazy val businessTaxAccountPage: String = conf.getString("microservice.services.auth.business-tax-account.serviceRedirectUrl")
 }

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -37,17 +37,22 @@ class ApplicationController @Inject()(mcc: MessagesControllerComponents,
   }
 
   def cancel: Action[AnyContent] = Action { implicit request =>
-      val serviceRedirectUrl: String = Try{appConfig.conf.getString("cancelRedirectUrl")}.getOrElse("https://www.gov.uk/")
-      Redirect(serviceRedirectUrl)
-    }
+    val serviceRedirectUrl: String = Try{appConfig.conf.getString("cancelRedirectUrl")}.getOrElse("https://www.gov.uk/")
+    Redirect(serviceRedirectUrl)
+  }
 
-    def logout: Action[AnyContent] = Action { implicit request =>
-      Redirect(appConfig.serviceSignOut).withNewSession
-    }
+  def logout: Action[AnyContent] = Action { implicit request =>
+    Redirect(appConfig.serviceSignOut).withNewSession
+  }
 
-    def keepAlive: Action[AnyContent] = Action.async { implicit request =>
-      authAction.authorisedForNoEnrolments { implicit authContext =>
-        Future.successful(Ok("OK"))
-      }
+  def keepAlive: Action[AnyContent] = Action.async { implicit request =>
+    authAction.authorisedForNoEnrolments { implicit authContext =>
+      Future.successful(Ok("OK"))
     }
   }
+
+  def redirectToGuidance: Action[AnyContent] = Action { implicit request =>
+    Redirect(appConfig.signOutRedirect).withNewSession
+  }
+
+}

--- a/app/views/error/individual.scala.html
+++ b/app/views/error/individual.scala.html
@@ -1,0 +1,51 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.ApplicationConfig
+
+@()(implicit messages: Messages, request: Request[AnyContent], appConfig: ApplicationConfig)
+
+<h1 class="heading-large">@messages("unauthorised.header")</h1>
+
+<h2>@messages("unauthorised.UK.h2")</h2>
+
+<p class="body">@messages("unauthorised.UK.p")</p>
+
+<h2>@messages("unauthorised.nonUK.h2")</h2>
+
+<p>@messages("unauthorised.nonUK.p1")</p>
+
+<p>
+ @messages("unauthorised.nonUK.p2.a")
+ <a href=@appConfig.createNewGatewayLink>@messages("unauthorised.nonUK.link")</a>
+ @messages("unauthorised.nonUK.p2.b")
+</p>
+
+<div class="notice">
+ <i class="icon icon-important">
+  <span class="visuallyhidden">Warning</span>
+ </i>
+ <strong class="bold-small">@messages("unauthorised.nonUK.warning")</strong>
+</div>
+
+<p>@messages("unauthorised.nonUK.p3")</p>
+
+<p>@messages("unauthorised.nonUK.p4")</p>
+
+
+<a href="/ated/sign-out-individual">
+ <button class="button">@messages("unauthorised.button.signout")</button>
+</a>

--- a/app/views/unauthorised.scala.html
+++ b/app/views/unauthorised.scala.html
@@ -15,16 +15,17 @@
  *@
 
 @import config.ApplicationConfig
+@import error.individual
+
 @()(implicit isSa: Boolean, messages: Messages, request: Request[AnyContent], appConfig: ApplicationConfig)
 
 
-
-@atedNoAuthMain(title = Messages("unauthorised.title"), supportLinkEnabled = false) {
+@atedNoAuthMain(title = messages("unauthorised.title"), supportLinkEnabled = false) {
 
   @if(isSa) {
-    <h1>@Messages("unauthorised.sa.header")</h1>
+    <h1>@messages("unauthorised.sa.header")</h1>
   } else {
-    <h1>@Messages("unauthorised.header")</h1>
+    @individual()
   }
 
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -205,6 +205,8 @@ GET      /feedback                                                         contr
 GET      /feedback/thanks                                                  controllers.LeaveFeedbackController.thanks(return: String)
 POST     /feedback/submit                                                  controllers.LeaveFeedbackController.submitFeedback(return: String)
 
+GET      /sign-out-individual                                                controllers.ApplicationController.redirectToGuidance()
+
 GET     /draft/delete/confirmation/view/:periodKey/:returnType           controllers.DraftDeleteConfirmationController.view(propertyKey: Option[String] ?=None, periodKey: Int, returnType: String)
 POST    /draft/delete/confirmation/submit/:periodKey/:returnType         controllers.DraftDeleteConfirmationController.submit(propertyKey: Option[String] ?=None, periodKey: Int, returnType: String)
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -88,6 +88,8 @@ microservice {
       host = localhost
       port = 8500
       login-path = "sign-in"
+      create-account = "https://www.tax.service.gov.uk/gg/sign-in?continue=/ated/home/&origin=ated-frontend"
+      sign-out-redirect = "https://www.gov.uk/guidance/register-for-the-annual-tax-on-enveloped-dwellings-online-service"
       login-callback {
         url = "http://localhost:9916/ated/home"
       }

--- a/conf/messages
+++ b/conf/messages
@@ -73,9 +73,22 @@ error.invalid.date.format = You must enter a valid date
 
 ##### UNAUTHORISED PAGE
 
-unauthorised.title = Unauthorised
-unauthorised.header = You are not authorised to use this service
+unauthorised.title = You need to sign in with a different Gateway ID
+unauthorised.header = You need to sign in with a different Gateway ID
+unauthorised.UK.h2 = UK businesses, trusts and partnerships
+unauthorised.UK.p = You need to use the Gateway ID you use to access Corporation Tax for a company or Self Assessment for a trust or partnership.
+unauthorised.nonUK.h2 = Non-UK businesses, trusts and partnerships, including non-resident landlords
+unauthorised.nonUK.p1 = If you are registering for ATED for the first time, and you are registering a business based outside the UK, you will need to create an organisation account.
+unauthorised.nonUK.p2.a = First
+unauthorised.nonUK.link = create a new Gateway ID from this page
+unauthorised.nonUK.p2.b = by selecting 'Create sign-in details'. When you are asked what type of account you require, select 'Organisation'.
+unauthorised.nonUK.warning = Do not set up a new Gateway ID if your business is already registered for ATED
+unauthorised.nonUK.p3 = The person or agent who registered your business for ATED should sign in.
+unauthorised.nonUK.p4 = If you are stuck, use the 'Get help with this service' link to find out who registererd your company for ATED and how to get access. Give them your ATED reference number if you have it.
+unauthorised.button.signout = Sign out
+
 unauthorised.sa.header = You are trying to sign in with your Self Assessment ID. If you are an overseas landlord or client you need to use your limited company ID
+
 
 ##### WELCOME
 

--- a/test/controllers/ApplicationControllerSpec.scala
+++ b/test/controllers/ApplicationControllerSpec.scala
@@ -109,7 +109,7 @@ class ApplicationControllerSpec extends PlaySpec with MockitoSugar with GuiceOne
 
         "load the unauthorised page" in new Setup {
           getWithUnAuthorisedUser { result =>
-            contentAsString(result) must include("You are not authorised to use this service")
+            contentAsString(result) must include("You need to sign in with a different Gateway ID")
           }
         }
       }
@@ -147,6 +147,16 @@ class ApplicationControllerSpec extends PlaySpec with MockitoSugar with GuiceOne
         keepAliveWithAuthorisedUser { result =>
           status(result) must be(OK)
         }
+      }
+    }
+
+    "redirectToGuidance" must {
+      "redirect the user" in new Setup {
+        val userId = s"user-${UUID.randomUUID}"
+        val authMock = authResultDefault(AffinityGroup.Individual, defaultEnrolmentSet)
+        setAuthMocks(authMock)
+        val result = testApplicationController.redirectToGuidance().apply(SessionBuilder.buildRequestWithSession(userId))
+        redirectLocation(result).get must include("/guidance/register-for-the-annual-tax-on-enveloped-dwellings-online-service")
       }
     }
   }


### PR DESCRIPTION
# DL-2333 Amended content for individual auth failure

**Maintenance** 

Added new unauthorised view for individuals trying to access ATED. The link URLs are in config so that changing without a redeployment is an option.

## Checklist

*Reviewee* (Chris)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Iyke)
 - [x]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date