### PR TITLE
DL-2502 Select previous address flow change

### DIFF
--- a/app/controllers/propertyDetails/AddressLookupController.scala
+++ b/app/controllers/propertyDetails/AddressLookupController.scala
@@ -67,10 +67,10 @@ extends FrontendController(mcc) with PropertyDetailsHelpers with ClientHelper wi
   def find(id: Option[String], periodKey: Int, mode: Option[String] = None): Action[AnyContent] = Action.async { implicit request =>
     authAction.authorisedAction { implicit authContext =>
       ensureClientContext {
+        val backLink = Some(controllers.routes.ExistingReturnQuestionController.view(periodKey, "charge").url)
         addressLookupForm.bindFromRequest.fold(
           formWithError => {
-            currentBackLink.flatMap(backLink =>
-              Future.successful(BadRequest(views.html.propertyDetails.addressLookup(id, periodKey, formWithError, mode, backLink)))
+              Future.successful(BadRequest(views.html.propertyDetails.addressLookup(id, periodKey, formWithError, mode, backLink))
             )
           },
           searchCriteria => {
@@ -93,7 +93,7 @@ extends FrontendController(mcc) with PropertyDetailsHelpers with ClientHelper wi
           case Some(x) => controllers.propertyDetails.routes.PropertyDetailsAddressController.view(x, fromConfirmAddressPage = false, periodKey, mode)
           case None => controllers.propertyDetails.routes.PropertyDetailsAddressController.createNewDraft(periodKey)
         }
-        redirectWithBackLinkDontOverwriteOldLink(
+        redirectWithBackLink(
           propertyDetailsAddressId,
           redirectUrl,
           Some(controllers.propertyDetails.routes.AddressLookupController.view(id, periodKey, mode).url)

--- a/app/controllers/propertyDetails/PropertyDetailsAddressController.scala
+++ b/app/controllers/propertyDetails/PropertyDetailsAddressController.scala
@@ -155,18 +155,23 @@ class PropertyDetailsAddressController @Inject()(mcc: MessagesControllerComponen
   def save(id: Option[String], periodKey: Int, mode: Option[String], fromConfirmAddressPage: Boolean): Action[AnyContent] = Action.async { implicit request =>
     authAction.authorisedAction { implicit authContext =>
       ensureClientContext {
+        val backLink = {
+          id match {
+            case Some(id) if fromConfirmAddressPage =>
+              Some(controllers.propertyDetails.routes.ConfirmAddressController.view(id, periodKey, mode).url)
+            case _ =>
+              Some(controllers.propertyDetails.routes.AddressLookupController.view(id, periodKey, mode).url)
+          }
+        }
         propertyDetailsAddressForm.bindFromRequest.fold(
           formWithError => {
-            currentBackLink.map(backLink =>
-              BadRequest(views.html.propertyDetails.propertyDetailsAddress(
+              Future.successful(BadRequest(views.html.propertyDetails.propertyDetailsAddress(
                 id,
                 periodKey,
                 formWithError,
                 mode,
                 backLink,
-                fromConfirmAddressPage = fromConfirmAddressPage))
-            )
-          },
+                fromConfirmAddressPage = fromConfirmAddressPage)))},
           propertyDetails => {
             val trimmedPostCode = AtedUtils.formatPostCode(propertyDetails.postcode)
             val trimmedAddressProperty = propertyDetails.copy(postcode = trimmedPostCode)

--- a/app/views/confirmPastReturn.scala.html
+++ b/app/views/confirmPastReturn.scala.html
@@ -20,14 +20,25 @@
 @import views.html.helpers._
 
 @import config.ApplicationConfig
-@(confirmExistingReturn: Form[YesNoQuestion], periodKey: Int, returnType: String, backLink: Option[String])(implicit authContext: StandardAuthRetrievals, messages: Messages, request: Request[AnyContent], appConfig: ApplicationConfig)
+@(confirmExistingReturn: Form[YesNoQuestion],
+        periodKey: Int,
+        returnType: String,
+        backLink: Option[String])(implicit authContext: StandardAuthRetrievals, messages: Messages, request: Request[AnyContent], appConfig: ApplicationConfig)
 
-@atedMain(title = Messages("ated.confirm-past-return-question.title")) {
-@pageHeadersAndError(backLink, "pre-header", Messages("ated.return-type.pre-header"), "return-type-header", Messages("ated.confirm-past-return-question.header"),
-Some(atedErrorSummary(confirmExistingReturn, "ated.confirm-past-return-question.error.general")))
+@atedMain(title = Messages("ated.confirm-past-return-question.header", (periodKey-1).toString, periodKey.toString)) {
+@pageHeadersAndError(
+    backLink,
+    "pre-header",
+    Messages("ated.return-type.pre-header"),
+    "return-type-header",
+    Messages("ated.confirm-past-return-question.header", (periodKey-1).toString, periodKey.toString),
+    Some(atedErrorSummary(confirmExistingReturn, "ated.confirm-past-return-question.error.general")))
+
+    <p class="page-header-margin">
+        @Messages("ated.confirm-past-return.p1", (periodKey-1).toString, periodKey.toString)
+    </p>
 
     @form(action = controllers.routes.ExistingReturnQuestionController.submit(periodKey, returnType)) {
-
         <div class="form-group" id="pastReturn">
         @atedInputRadioGroupNew(
             confirmExistingReturn("yesNo"),
@@ -42,7 +53,7 @@ Some(atedErrorSummary(confirmExistingReturn, "ated.confirm-past-return-question.
         )
         </div>
 
-        <button class="button" id="submit" type="submit">@Messages("ated.continue")</button>
+        <button class="button" id="submit" type="submit">@Messages("ated.save-and-continue")</button>
 
     }
 }

--- a/app/views/helpers/pageHeadersAndError.scala.html
+++ b/app/views/helpers/pageHeadersAndError.scala.html
@@ -19,25 +19,26 @@
 @if(backLink.isDefined){
 <a id="backLinkHref" class="link-back" href='@backLink'>@Messages("ated.back")</a>
 @errorDisplay
-<header class="page-header">
-  <h1 id=@headerId class="heading-xlarge">@headerValue</h1>
+    <header class="page-header">
   <p id=@subHeaderId class="heading-secondary"><span class="visuallyhidden">
     @if(subHeaderPrefix.isDefined) {
       @subHeaderPrefix.getOrElse("")
   } else {
     @Messages("ated.screen-reader.section")
   } </span>@subHeaderValue</p>
+    <h1 id=@headerId class="heading-xlarge">@headerValue</h1>
 </header>
 } else {
 <a id="backLinkHref" class="link-back" href='@backLink'>@Messages("ated.back")</a>
 @errorDisplay
 <header class="page-header page-header-margin">
-  <h1 id=@headerId class="heading-xlarge">@headerValue</h1>
+
   <p id=@subHeaderId class="heading-secondary"><span class="visuallyhidden">
     @if(subHeaderPrefix.isDefined) {
         @subHeaderPrefix.getOrElse("")
   } else {
     @Messages("ated.screen-reader.section")
   } </span>@subHeaderValue</p>
+    <h1 id=@headerId class="heading-xlarge">@headerValue</h1>
 </header>
 }

--- a/app/views/propertyDetails/confirmAddress.scala.html
+++ b/app/views/propertyDetails/confirmAddress.scala.html
@@ -28,10 +28,10 @@
 @import _root_.utils._
 
 @atedMain(title = Messages("ated.confirm-address.title")) {
- @pageHeadersAndError(backLink, "pre-heading", Messages(AtedUtils.getPropertyDetailsPreHeader(mode)), "confirm-address-header", Messages("ated.confirm-address.header"))
+    @pageHeadersAndError(backLink, "pre-heading", Messages(AtedUtils.getPropertyDetailsPreHeader(mode)), "confirm-address-header", Messages("ated.confirm-address.header"))
 
     <div id="address">
-        <ul style="list-style-type:none">
+        <ul style="list-style-type: none">
             <li id="address-line1">@propertyDetails.line_1</li>
             <li id="address-line2">@propertyDetails.line_2</li>
             <li id="address-line3">@propertyDetails.line_3</li>
@@ -40,15 +40,23 @@
         </ul>
     </div>
 
-    <div class="form-group">
+    <div class="margin-top-default">
         <a href="@controllers.propertyDetails.routes.PropertyDetailsAddressController.view(id, fromConfirmAddressPage = true, periodKey, mode)"
         id="edit-address-link"
         data-journey-click="ated-fronted:click:manual-entry"
-        onkeyup='spaceBarHandler(event,"@controllers.propertyDetails.routes.PropertyDetailsAddressController.view(id, fromConfirmAddressPage = true, periodKey, mode)")'>
-        <p id="editAddress">@Messages("ated.confirm-address.editAddress")</p></a>
+        onkeyup='spaceBarHandler(event, "@controllers.propertyDetails.routes.PropertyDetailsAddressController.view(id, fromConfirmAddressPage = true, periodKey, mode)")'>
+            <p id="editAddress">@Messages("ated.confirm-address.editAddress")</p>
+        </a>
 
-    @form(action=controllers.propertyDetails.routes.ConfirmAddressController.submit(id, periodKey, mode)) {
-        <p><button class="button" id="submit" type="submit">@Messages("ated.confirm-and-continue")</button></p>
-    }
+        <a href="@controllers.routes.ExistingReturnQuestionController.view(periodKey, "charge")">
+            <p id="selectADifferentProperty">@Messages("ated.confirm-address.selectDifferentProperty")</p>
+        </a>
+
+        @form(action = controllers.propertyDetails.routes.ConfirmAddressController.submit(id, periodKey, mode)) {
+            <p>
+                <button class="button reference-group" id="submit" type="submit">@Messages("ated.confirm-and-continue")</button>
+            </p>
+        }
     </div>
+
 }

--- a/app/views/propertyDetails/propertyDetailsAddress.scala.html
+++ b/app/views/propertyDetails/propertyDetailsAddress.scala.html
@@ -58,9 +58,13 @@ case _ => oldFormBundleNo.getOrElse("")
             @pageHeadersAndError(backLink, messages("pre-heading"), messages(AtedUtils.getPropertyDetailsPreHeader(mode)), "property-details-header", pageTitle,
                 Some(atedErrorSummary(propertyDetailsForm, "ated.property-details-address-error.general")))
 
+        @if(mode.contains("editSubmitted")){
+            <p>@Messages("ated.property-details.p")</p>
+        }
+
         @form(action = controllers.propertyDetails.routes.PropertyDetailsAddressController.save(id, periodKey, mode, fromConfirmAddressPage)) {
 
-            <fieldset>
+            <fieldset class="page-header-margin">
 
                 <legend class="visuallyhidden">@Messages("ated.property-details.header")</legend>
 
@@ -107,7 +111,7 @@ case _ => oldFormBundleNo.getOrElse("")
                 </div>
             }
 
-            <button class="button" id="submit" type="submit">@Messages("ated.save-and-continue")</button>
+            <button class="button page-header-margin" id="submit" type="submit">@Messages("ated.save-and-continue")</button>
 
         }
     }

--- a/app/views/propertyDetails/selectPreviousReturn.scala.html
+++ b/app/views/propertyDetails/selectPreviousReturn.scala.html
@@ -14,17 +14,10 @@
  * limitations under the License.
  *@
 
-@import models._
-@import forms.AtedForms._
-@import uk.gov.hmrc.play.views.html._
-@import uk.gov.hmrc.play.views.html.helpers._
-@import org.joda.time.format.DateTimeFormat
-@import org.joda.time.LocalDate
-@import utils._
-@import views.html.helpers._
-@import views.html.helpers.error._
-
 @import config.ApplicationConfig
+@import models._
+@import uk.gov.hmrc.play.views.html.helpers._
+@import views.html.helpers._
 @(periodKey: Int, returnType: String, addressResultsForm: Form[AddressSelected], prevReturns: Seq[PreviousReturns], backLink: Option[String])(implicit authContext: StandardAuthRetrievals, messages: Messages, request: Request[AnyContent], appConfig: ApplicationConfig)
 
 @analyticsJs = {
@@ -48,9 +41,22 @@
           '_labelAfter -> true,
           '_trackGA -> true
         )
+          <details>
+              <summary id="titleNumber-reveal" class="summary" data-journey-click="accordion - click:@messages("ated.select-past-return.header"):@messages("ated.select-past-return.reveal")">
+              @messages("ated.select-past-return.reveal")
+              </summary>
+              <div class="panel-indent">
+                  <p id="titleNumber-text">
+                      @messages("ated.select-past-return.reveal.text.1")
+                      <a href="@controllers.propertyDetails.routes.SelectExistingReturnAddressController.continueWithThisReturnRedirect(periodKey, returnType)">@messages("ated.select-past-return.reveal.text.2")</a>,
+                      @messages("ated.select-past-return.reveal.text.3")
+                      <a href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/annual-tax-on-enveloped-dwellings-ated">@messages("ated.select-past-return.reveal.text.4")</a>
+                      @messages("ated.select-past-return.reveal.text.5")
 
-      <button class="button margin-top-default" id="submit" type="submit">@Messages("ated.save-and-continue")</button>
+                  </p>
+              </div>
+          </details>
+      <button class="button reference-group" id="submit" type="submit">@Messages("ated.save-and-continue")</button>
     }
-
   }
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -128,6 +128,7 @@ POST     /liability/address-lookup/find/:periodKey                    controller
 POST     /liability/address-lookup/save/:periodKey                    controllers.propertyDetails.AddressLookupController.save(propertyKey: Option[String] ?=None, periodKey: Int, mode: Option[String] ?=None)
 
 GET      /liability/confirm-address/view/:periodKey/:propertyKey                   controllers.propertyDetails.ConfirmAddressController.view(propertyKey: String, periodKey: Int, mode: Option[String] ?=None)
+GET      /liability/confirm-address/view/:formBundleNo                             controllers.propertyDetails.ConfirmAddressController.editSubmittedReturn(formBundleNo: String)
 POST     /liability/confirm-address/save/:periodKey/:propertyKey                    controllers.propertyDetails.ConfirmAddressController.submit(propertyKey: String, periodKey: Int, mode: Option[String] ?=None)
 
 GET      /liability/address-lookup/manual/:periodKey                  controllers.propertyDetails.AddressLookupController.manualAddressRedirect(propertyKey: Option[String] ?=None, periodKey: Int, mode: Option[String] ?=None)
@@ -222,3 +223,4 @@ POST     /existing-return/confirmation/:periodKey/:returnType                   
 
 GET     /existing-return/select/:periodKey/:returnType                        controllers.propertyDetails.SelectExistingReturnAddressController.view(periodKey: Int, returnType: String)
 POST     /existing-return/select/:periodKey/:returnType                        controllers.propertyDetails.SelectExistingReturnAddressController.continue(periodKey: Int, returnType: String)
+GET     /liability/create/address/:periodKey/:returnType                        controllers.propertyDetails.SelectExistingReturnAddressController.continueWithThisReturnRedirect(periodKey: Int, returnType: String)

--- a/conf/messages
+++ b/conf/messages
@@ -399,6 +399,7 @@ ated.property-details.title = Enter the address of the property manually
 ated.property-details.editAddress = Edit address
 ated.property-details.header = Enter the address of the property manually
 ated.property-details.header.2 = Edit address
+ated.property-details.p = If you change the first line of this address you need to inform HMRC to ensure it is recognised as the same property
 ated.property-details.property-address.lookup.title = Lookup address
 ated.property-details.property-address = Property address
 ated.property-details.title.title =  What is the property’s title number? (optional)
@@ -948,6 +949,7 @@ ated.address-lookup.error.general.selected-address = There is something wrong wi
 ated.confirm-address.title = Confirm address
 ated.confirm-address.header = Confirm address
 ated.confirm-address.editAddress = Edit address
+ated.confirm-address.selectDifferentProperty = Select a different property
 
 ##### EDIT LIABILITY RETURN
 
@@ -1366,20 +1368,27 @@ ated.delete-draft.title = Are you sure you want to delete this draft return?
 ated.delete-draft.error = delete draft return
 ated.delete-drafts.error.general.yesNo = Select if you want to delete this draft or not
 yes-no.error.mandatory.delete.draft = You must answer this question
-yes-no.error.mandatory.existing.returns = The existing return question must be answered
+yes-no.error.mandatory.existing.returns = Select yes if you filed a return for this property last year
 yes-no.error.mandatory.draft.delete = The existing return question must be answered
 
 
 ##### SELECT PAST RETURNS
 
 ated.confirm-past-return-question.title = Did you file a return for this property last year?
-ated.confirm-past-return-question.header = Did you file a return for this property last year?
+ated.confirm-past-return-question.header = Did you file a return for this property in {0} to {1}?
 ated.confirm-past-return.error = existing return
-ated.confirm-past-return-question.error.general.yesNo = The existing return question must be answered
+ated.confirm-past-return.p1 = Did you file a return for this property in the previous chargeable period - April 1 {0} to March 31 {1}
+ated.confirm-past-return-question.error.general.yesNo = Select yes if you filed a return for this property last year
 
-ated.select-past-return.title = Select the previous return this new return relates to
-ated.select-past-return.header = Select the previous return this new return relates to
-ated.select-past-return.general.selected = There is a problem with the previous return question
+ated.select-past-return.title = Select the property from your previous year returns
+ated.select-past-return.header = Select the property from your previous year returns
+ated.select-past-return.general.selected = Select the property from your previous year returns
+ated.select-past-return.reveal = The property I want is not listed
+ated.select-past-return.reveal.text.1 = If the property is not listed, you can
+ated.select-past-return.reveal.text.2 = continue with this return
+ated.select-past-return.reveal.text.3 = but you must contact
+ated.select-past-return.reveal.text.4 = contact the ATED helpline
+ated.select-past-return.reveal.text.5 = to ensure HMRC has this information.
 
 urbanner.message.text = Help improve digital services by joining the HMRC user panel (opens in new window)
 urbanner.message.reject = No thanks

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -98,7 +98,7 @@
  </check>
  <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
   <parameters>
-   <parameter name="maxLength"><![CDATA[50]]></parameter>
+   <parameter name="maxLength"><![CDATA[100]]></parameter>
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">

--- a/test/controllers/ExistingReturnQuestionControllerSpec.scala
+++ b/test/controllers/ExistingReturnQuestionControllerSpec.scala
@@ -14,6 +14,22 @@
  * limitations under the License.
  */
 
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import java.util.UUID
@@ -155,18 +171,18 @@ class ExistingReturnQuestionControllerSpec extends PlaySpec with GuiceOneServerP
           getWithAuthorisedUser { result =>
             status(result) must be(OK)
             val document = Jsoup.parse(contentAsString(result))
-            document.title() must be(TitleBuilder.buildTitle("Did you file a return for this property last year?"))
+            document.title() must be(TitleBuilder.buildTitle("Did you file a return for this property in 2014 to 2015?"))
             document.getElementById("return-type-header")
-              .text() must be("Did you file a return for this property last year?")
+              .text() must be("Did you file a return for this property in 2014 to 2015?")
           }
         }
         "show the return type view with saved data" in new Setup {
           getWithAuthorisedUserWithSomeData { result =>
             status(result) must be(OK)
             val document = Jsoup.parse(contentAsString(result))
-            document.title() must be(TitleBuilder.buildTitle("Did you file a return for this property last year?"))
+            document.title() must be(TitleBuilder.buildTitle("Did you file a return for this property in 2014 to 2015?"))
             document.getElementById("return-type-header")
-              .text() must be("Did you file a return for this property last year?")
+              .text() must be("Did you file a return for this property in 2014 to 2015?")
           }
         }
       }
@@ -182,7 +198,7 @@ class ExistingReturnQuestionControllerSpec extends PlaySpec with GuiceOneServerP
               result =>
                 status(result) must be(BAD_REQUEST)
                 val doc = Jsoup.parse(contentAsString(result))
-                doc.getElementsByClass("error-notification").html() must include("The existing return question must be answered")
+                doc.getElementsByClass("error-notification").html() must include("Select yes if you filed a return for this property last year")
             }
           }
 


### PR DESCRIPTION
Select previous address - guide user to select continuity of record correctly

**New feature** 

"Yes" flow for "/ated/existing-return/confirmation/2017/charge"

![image](https://user-images.githubusercontent.com/50663032/74675092-b7503a80-51aa-11ea-8e81-9874591beed0.png)


## Checklist

*Iyke* 
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date