### PR TITLE
DL-2766: Added configurable peak and non-peak content to ated home

### DIFF
--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -42,7 +42,7 @@ class ApplicationConfig @Inject()(val conf: ServicesConfig,
   lazy val atedFrontendHost: String = conf.getString("microservice.services.ated-frontend.host")
   lazy val defaultTimeoutSeconds: Int = loadConfig("defaultTimeoutSeconds").toInt
   lazy val timeoutCountdown: Int = loadConfig("timeoutCountdown").toInt
-  lazy val urBannerToggle:Boolean = loadConfig("urBanner.toggle").toBoolean
+  lazy val urBannerToggle: Boolean = loadConfig("urBanner.toggle").toBoolean
   lazy val urBannerLink: String = loadConfig("urBanner.link")
   lazy val serviceSignOut:String = loadConfig("service-signout.url")
 
@@ -65,4 +65,6 @@ class ApplicationConfig @Inject()(val conf: ServicesConfig,
   lazy val clientApproveAgentMandate: String = conf.getString("microservice.services.agent-client-mandate-frontend.atedClientApproveAgentUri")
   lazy val agentRedirectedToMandate: String = conf.getString("microservice.services.agent-client-mandate-frontend.atedAgentJourneyStartUri")
   lazy val businessTaxAccountPage: String = conf.getString("microservice.services.auth.business-tax-account.serviceRedirectUrl")
+  lazy val atedPeakStartDay: String = conf.getString(key = "atedPeakStartDay")
+
 }

--- a/app/services/DateService.scala
+++ b/app/services/DateService.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import org.joda.time.LocalDate
+import javax.inject.Singleton
+
+@Singleton
+class DateService {
+
+  def now(): LocalDate = LocalDate.now()
+
+}

--- a/app/views/accountSummary.scala.html
+++ b/app/views/accountSummary.scala.html
@@ -17,9 +17,11 @@
 @import models._
 @import config.ApplicationConfig
 @import play.twirl.api.HtmlFormat
-
-@(summaryReturnsWithDrafts: SummaryReturnsModel, correspondence: Option[Address], organisationName: Option[String], clientBanner: Html)(implicit authContext: StandardAuthRetrievals, messages: Messages, request: Request[AnyContent], appConfig: ApplicationConfig)
 @import views.html.helpers._
+
+@(summaryReturnsWithDrafts: SummaryReturnsModel, correspondence: Option[Address], organisationName: Option[String],
+        clientBanner: Html, duringPeak: Boolean, currentYear: Int)(implicit authContext: StandardAuthRetrievals,
+        messages: Messages, request: Request[AnyContent], appConfig: ApplicationConfig)
 
 @analyticsJs = {
     ga('set', 'page', document.location.pathname);
@@ -36,7 +38,8 @@
     sidebarLinks = Some(_accountSummary_sideBar(summaryReturnsWithDrafts.atedBalance, correspondence, organisationName)),
     sidebarClass = Some("related"),
     banner = clientBanner,
-    analyticsAdditionalJs = Some(analyticsJs), showUrBanner = Some(true)
+    analyticsAdditionalJs = Some(analyticsJs),
+    showUrBanner = Some(true)
 ) {
 
     @pageHeadersAndError(None,
@@ -46,6 +49,8 @@
         Messages("ated.summary-return.header"),
         subHeaderPrefix = Some(Messages("ated.screen-reader.section-name"))
     )
+
+    @peakGuidance(duringPeak, currentYear)
 
     @if(summaryReturnsWithDrafts.allReturns.isEmpty) {
         <h2 class="heading-small" id="return-summary-no-returns">@Messages("ated.account-summary.agent.no-returns")</h2>

--- a/app/views/atedMain.scala.html
+++ b/app/views/atedMain.scala.html
@@ -16,10 +16,13 @@
 
 @import play.twirl.api.HtmlFormat
 @import config.ApplicationConfig
+@import uk.gov.hmrc.play.views.helpers.AttorneyRegime
+@import uk.gov.hmrc.play.views.html.{layouts => uiLayouts}
+
 @(title: String,
   userLoggedIn: Boolean = true,
   hasBanner: Boolean = false,
-  showUrBanner:Option[Boolean] = Some(false),
+  showUrBanner: Option[Boolean] = Some(false),
   supportLinkEnabled: Boolean = true,
   banner: Html = HtmlFormat.empty,
   scriptElement: Option[Html] = None,
@@ -27,9 +30,6 @@
   sidebarLinks: Option[Html] = None,
   sidebarClass: Option[String] = None,
   analyticsAdditionalJs: Option[Html] = None)(mainContent: Html)(implicit authContext: StandardAuthRetrievals, messages: Messages, request: Request[AnyContent], appConfig: ApplicationConfig)
-
-    @import uk.gov.hmrc.play.views.helpers.AttorneyRegime
-@import uk.gov.hmrc.play.views.html.{layouts => uiLayouts}
 
 @scriptElement = {
     <script src='@controllers.routes.Assets.versioned("jquery/jquery-ui.min.js")'></script>
@@ -40,9 +40,9 @@
 }
     <script>
         @if(userLoggedIn) {
-        $.timeoutDialog({timeout: @appConfig.defaultTimeoutSeconds, countdown: @appConfig.timeoutCountdown, keep_alive_url: '@controllers.routes.ApplicationController.keepAlive', logout_url: '@controllers.routes.ApplicationController.logout', logout_redirect_url: '@controllers.routes.ApplicationController.logout', restart_on_yes: true, background_no_scroll: true});
-        var dialogOpen;
-    }
+            $.timeoutDialog({timeout: @appConfig.defaultTimeoutSeconds, countdown: @appConfig.timeoutCountdown, keep_alive_url: '@controllers.routes.ApplicationController.keepAlive', logout_url: '@controllers.routes.ApplicationController.logout', logout_redirect_url: '@controllers.routes.ApplicationController.logout', restart_on_yes: true, background_no_scroll: true});
+            var dialogOpen;
+        }
     </script>
 
 @linkElement = {
@@ -73,6 +73,7 @@
   banner = Some(mainBanner),
   userLoggedIn = userLoggedIn,
   linkElement = Some(linkElement),
-  analyticsJs = analyticsAdditionalJs, isUserResearchBannerVisible = showUrBanner.getOrElse(false)) {
+  analyticsJs = analyticsAdditionalJs,
+  isUserResearchBannerVisible = showUrBanner.getOrElse(false)) {
     @mainContent
   }

--- a/app/views/helpers/peakGuidance.scala.html
+++ b/app/views/helpers/peakGuidance.scala.html
@@ -1,0 +1,29 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import helpers.warning
+
+@(duringPeak: Boolean, currentYear: Int)(implicit messages: Messages)
+
+@if(duringPeak){
+    @warning(messages("ated.account-summary.peak-guidance.warning", currentYear.toString, (currentYear + 1).toString))
+    <p>@messages("ated.account-summary.peak-guidance.text.1", currentYear.toString)</p>
+    <p>@messages("ated.account-summary.peak-guidance.text.2")</p>
+}else{
+    @warning(messages("ated.account-summary.outside-peak-guidance.warning"))
+    <p>@messages("ated.account-summary.outside-peak-guidance.text", (currentYear + 1).toString,
+        (currentYear + 2).toString)</p>
+}

--- a/app/views/helpers/warning.scala.html
+++ b/app/views/helpers/warning.scala.html
@@ -1,0 +1,24 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(message: String)(implicit messages: Messages)
+
+<div class="notice">
+    <i class="icon icon-important">
+        <span class="visuallyhidden">@messages("ated.warning")</span>
+    </i>
+    <strong class="bold-small">@message</strong>
+</div><br/>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -16,6 +16,10 @@
 
 @import play.twirl.api.HtmlFormat
 @import config.ApplicationConfig
+@import layouts.{govuk_template => hmrcGovUkTemplate}
+@import uk.gov.hmrc.play.views.html.{helpers => uiHelpers, layouts => uiLayouts}
+@import _root_.utils.SessionUtils
+
 @(appConfig: ApplicationConfig,
   supportLinkEnabled: Boolean = false,
   title: String,
@@ -27,12 +31,8 @@
   scriptElement: Option[Html] = None,
   linkElement : Option[Html] = None,
   analyticsJs: Option[Html] = None,
-  isUserResearchBannerVisible:Boolean = false
+  isUserResearchBannerVisible: Boolean = false
   )(mainContent: Html = HtmlFormat.empty)(implicit messages: Messages, request: Request[AnyContent])
-
-@import layouts.{govuk_template => hmrcGovUkTemplate}
-@import uk.gov.hmrc.play.views.html.{helpers => uiHelpers, layouts => uiLayouts}
-@import _root_.utils.SessionUtils
 
 @head = {
   @uiLayouts.head(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -152,8 +152,9 @@ service-signout {
   url = "http://localhost:9514/feedback/ATED"
 }
 
-
 cancelRedirectUrl: "https://www.gov.uk/"
+
+atedPeakStartDay: "17"
 
 auditing {
   enabled = true

--- a/conf/messages
+++ b/conf/messages
@@ -37,6 +37,7 @@ ated.print.name = Print name
 ated.date = Date
 ated.debit = debit
 ated.credit = credit
+ated.warning = Warning
 
 ##### ERROR MESSAGES
 
@@ -123,6 +124,11 @@ ated.account-summary.relief-text = From 1 April 2016 you will be able to use thi
 ated.account-summary.view-change-button = View or change
 ated.account-summary-back = Back to all your clients
 ated.account-summary-screen-reader = the period
+ated.account-summary.peak-guidance.warning = Deadline for {0} to {1} returns: 30 April {0}.
+ated.account-summary.peak-guidance.text.1 = This is the deadline for returns and payments for all ATED-eligible properties that you own on 1 April {0}.
+ated.account-summary.peak-guidance.text.2 = Returns for newly acquired ATED properties must be sent to HMRC within 30 days of the date of acquisition (90 days from start date for new builds).
+ated.account-summary.outside-peak-guidance.warning = Returns for newly acquired ATED properties must be sent to HMRC within 30 days (90 days for new builds).
+ated.account-summary.outside-peak-guidance.text = Returns for {0} to {1} for all properties in the scope of ATED are due by 30 April {0}.
 
 ##### SELECT PERIOD
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
@@ -15,4 +15,3 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.0.0")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.24")
 
 addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.6.1")
-

--- a/test/services/DateServiceSpec.scala
+++ b/test/services/DateServiceSpec.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import org.joda.time.LocalDate
+import org.scalatestplus.play.PlaySpec
+
+class DateServiceSpec extends PlaySpec {
+
+  ".now" should {
+    "return the current date" in {
+      val dateService: DateService = new DateService
+      dateService.now() must be(LocalDate.now)
+    }
+  }
+
+}

--- a/test/views/html/helpers/peakGuidanceSpec.scala
+++ b/test/views/html/helpers/peakGuidanceSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.html.helpers
+
+import config.ApplicationConfig
+import models.StandardAuthRetrievals
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.scalatest.{FeatureSpec, GivenWhenThen}
+import org.scalatestplus.play.guice.GuiceOneAppPerTest
+import play.api.i18n.{Lang, Messages, MessagesApi, MessagesImpl}
+import play.api.test.FakeRequest
+import testhelpers.MockAuthUtil
+
+class peakGuidanceSpec extends FeatureSpec with GivenWhenThen
+  with MockAuthUtil with GuiceOneAppPerTest {
+
+  implicit val request = FakeRequest()
+  implicit val appConfig: ApplicationConfig = mock[ApplicationConfig]
+  implicit lazy val authContext: StandardAuthRetrievals = organisationStandardRetrievals
+  implicit lazy val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+  implicit lazy val messages: Messages = MessagesImpl(Lang("en-GB"), messagesApi)
+
+  feature("The user is viewing returns guidance during peak") {
+
+    val currentYear: Int = 2020
+    lazy val view = views.html.helpers.peakGuidance(currentYear = currentYear, duringPeak = true)
+    lazy implicit val document: Document = Jsoup.parse(view.body)
+
+    scenario("User views the returns guidance during peak") {
+
+      Given("the user views the return guidance")
+      When("the current date is during peak period")
+      Then("the peak period content is displayed")
+
+      assert(document.select("strong").text() === "Deadline for 2020 to 2021 returns: 30 April 2020.")
+      assert(document.select("p").first.text() === "This is the deadline for returns and payments for all " +
+        "ATED-eligible properties that you own on 1 April 2020.")
+      assert(document.select("p").last().text() === "Returns for newly acquired ATED properties must be " +
+        "sent to HMRC within 30 days of the date of acquisition (90 days from start date for new builds).")
+
+    }
+  }
+
+  feature("The user is viewing returns guidance outside of peak") {
+
+    val currentYear: Int = 2020
+    lazy val view = views.html.helpers.peakGuidance(currentYear = currentYear, duringPeak = false)
+    lazy implicit val document: Document = Jsoup.parse(view.body)
+
+    scenario("The user is viewing returns guidance outside of peak") {
+
+      Given("the user views the return guidance")
+      When("the current date is outside of peak period")
+      Then("the outside of peak period guidance is displayed")
+
+      assert(document.select("strong").text() === "Returns for newly acquired ATED properties " +
+        "must be sent to HMRC within 30 days (90 days for new builds).")
+      assert(document.select("p").first.text() === "Returns for 2021 to 2022 for all properties in the " +
+        "scope of ATED are due by 30 April 2021.")
+
+    }
+  }
+}


### PR DESCRIPTION
**REMEMBER app-config-production change
https://github.com/hmrc/app-config-production/pull/5868**

# DL-2766 - Added configurable peak and non-peak content to ated home

**New feature** 

This story adds some content to the top of ated home which reminds users about their return deadlines. There is dynamic content depending on whether we are in or out of the ated peak period of xx March to 30th April. The day is configurable so we can set when this content is displayed each year.

## Checklist

*David Thornton* (Reviewee)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date