### PR TITLE
DL-2766: Updated logic on for ATED configurable deadline content

### DIFF
--- a/app/controllers/AccountSummaryController.scala
+++ b/app/controllers/AccountSummaryController.scala
@@ -26,6 +26,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.{DateService, DetailsService, SubscriptionDataService, SummaryReturnsService}
 import uk.gov.hmrc.http.ForbiddenException
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import utils.PeriodUtils
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -59,7 +60,8 @@ class AccountSummaryController @Inject()(mcc: MessagesControllerComponents,
           organisationName,
           clientBannerPartial.successfulContentOrEmpty,
           duringPeak,
-          dateService.now().getYear))
+          currentYear = dateService.now().getYear,
+          taxYearStartingYear = PeriodUtils.calculatePeriod(dateService.now())))
       }
     } recover {
       case _: ForbiddenException     =>

--- a/app/views/accountSummary.scala.html
+++ b/app/views/accountSummary.scala.html
@@ -20,7 +20,8 @@
 @import views.html.helpers._
 
 @(summaryReturnsWithDrafts: SummaryReturnsModel, correspondence: Option[Address], organisationName: Option[String],
-        clientBanner: Html, duringPeak: Boolean, currentYear: Int)(implicit authContext: StandardAuthRetrievals,
+        clientBanner: Html, duringPeak: Boolean, currentYear: Int,
+        taxYearStartingYear: Int)(implicit authContext: StandardAuthRetrievals,
         messages: Messages, request: Request[AnyContent], appConfig: ApplicationConfig)
 
 @analyticsJs = {
@@ -50,7 +51,7 @@
         subHeaderPrefix = Some(Messages("ated.screen-reader.section-name"))
     )
 
-    @peakGuidance(duringPeak, currentYear)
+    @peakGuidance(duringPeak, currentYear, taxYearStartingYear)
 
     @if(summaryReturnsWithDrafts.allReturns.isEmpty) {
         <h2 class="heading-small" id="return-summary-no-returns">@Messages("ated.account-summary.agent.no-returns")</h2>

--- a/app/views/helpers/peakGuidance.scala.html
+++ b/app/views/helpers/peakGuidance.scala.html
@@ -16,7 +16,7 @@
 
 @import helpers.warning
 
-@(duringPeak: Boolean, currentYear: Int)(implicit messages: Messages)
+@(duringPeak: Boolean, currentYear: Int, taxYearStartingYear: Int)(implicit messages: Messages)
 
 @if(duringPeak){
     @warning(messages("ated.account-summary.peak-guidance.warning", currentYear.toString, (currentYear + 1).toString))
@@ -24,6 +24,6 @@
     <p>@messages("ated.account-summary.peak-guidance.text.2")</p>
 }else{
     @warning(messages("ated.account-summary.outside-peak-guidance.warning"))
-    <p>@messages("ated.account-summary.outside-peak-guidance.text", (currentYear + 1).toString,
-        (currentYear + 2).toString)</p>
+    <p>@messages("ated.account-summary.outside-peak-guidance.text", (taxYearStartingYear + 1).toString,
+        (taxYearStartingYear + 2).toString)</p>
 }

--- a/conf/messages
+++ b/conf/messages
@@ -1392,7 +1392,7 @@ ated.select-past-return.general.selected = Select the property from your previou
 ated.select-past-return.reveal = The property I want is not listed
 ated.select-past-return.reveal.text.1 = If the property is not listed, you can
 ated.select-past-return.reveal.text.2 = continue with this return
-ated.select-past-return.reveal.text.3 = but you must contact
+ated.select-past-return.reveal.text.3 = but you must
 ated.select-past-return.reveal.text.4 = contact the ATED helpline
 ated.select-past-return.reveal.text.5 = to ensure HMRC has this information.
 

--- a/test/views/html/helpers/peakGuidanceSpec.scala
+++ b/test/views/html/helpers/peakGuidanceSpec.scala
@@ -37,8 +37,11 @@ class peakGuidanceSpec extends FeatureSpec with GivenWhenThen
 
   feature("The user is viewing returns guidance during peak") {
 
-    val currentYear: Int = 2020
-    lazy val view = views.html.helpers.peakGuidance(currentYear = currentYear, duringPeak = true)
+    lazy val view = views.html.helpers.peakGuidance(
+      duringPeak = true,
+      currentYear = 2020,
+      taxYearStartingYear = 2019
+    )
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
     scenario("User views the returns guidance during peak") {
@@ -56,10 +59,14 @@ class peakGuidanceSpec extends FeatureSpec with GivenWhenThen
     }
   }
 
-  feature("The user is viewing returns guidance outside of peak") {
+  feature("The user is viewing returns outside of peak") {
 
-    val currentYear: Int = 2020
-    lazy val view = views.html.helpers.peakGuidance(currentYear = currentYear, duringPeak = false)
+    lazy val view = views.html.helpers.peakGuidance(
+      duringPeak = false,
+      currentYear = 2020,
+      taxYearStartingYear = 2020
+    )
+
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
     scenario("The user is viewing returns guidance outside of peak") {


### PR DESCRIPTION
# DL-2766

Corrected logic to ensure the correct years are displayed on account summary when out of ATED peak. Before the years were based on current year and are now based on current tax year.

## Checklist

*Reviewee* (David Thornton)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date