### PR TITLE
DL-2763-b swapped paragraphs around

### DIFF
--- a/app/views/reliefs/changeReliefReturn.scala.html
+++ b/app/views/reliefs/changeReliefReturn.scala.html
@@ -33,8 +33,9 @@ ga('set', 'location', document.URL.split("?")[0]);
     @pageHeadersAndError(backLink, "pre-heading", Messages("ated.change-return.pre-header"), "relief-return-header", Messages("ated.change-relief-return.title"),
     Some(atedErrorSummary(editReliefForm, "ated.change-relief-return.error.empty.general")))
 
+    <p id="relief-return-change-text-2">@Messages("ated.change-relief-return.text.2")</p>
   <p id="relief-return-change-text">@Messages("ated.change-relief-return.text")</p>
-  <p id="relief-return-change-text-2">@Messages("ated.change-relief-return.text.2")</p>
+
     <details>
         <summary id="titleNumber-reveal" class="summary" data-journey-click="accordion - click:@messages("ated.change-relief-return.header"):@messages("ated.change-relief-return.accordian")">
         @messages("ated.change-relief-return.accordian")


### PR DESCRIPTION
DL-2763-b swapped paragraphs around

**New feature** 

**Before**
![image](https://user-images.githubusercontent.com/50663032/75443781-0ab84a80-595a-11ea-9f19-9e920243c8a1.png)



**After**
![image](https://user-images.githubusercontent.com/50663032/75443794-1146c200-595a-11ea-997b-74865444f006.png)



## Checklist

Iyke
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date