### PR TITLE
BackLinkChanges 

### DIFF
--- a/app/views/helpers/pageHeadersAndError.scala.html
+++ b/app/views/helpers/pageHeadersAndError.scala.html
@@ -29,7 +29,6 @@
     <h1 id=@headerId class="heading-xlarge">@headerValue</h1>
 </header>
 } else {
-<a id="backLinkHref" class="link-back" href='@backLink'>@Messages("ated.back")</a>
 @errorDisplay
 <header class="page-header page-header-margin">
 

--- a/test/views/editLiability/editLiabilitySpec.scala
+++ b/test/views/editLiability/editLiabilitySpec.scala
@@ -43,7 +43,7 @@ class editLiabilitySpec extends FeatureSpec with GuiceOneServerPerSuite with Moc
       When("The user views the page and clicks yes")
 
       implicit val request = FakeRequest()
-      val html = views.html.editLiability.editLiability(editLiabilityReturnTypeForm, "formBundleNo", 2015, editAllowed = true, None)
+      val html = views.html.editLiability.editLiability(editLiabilityReturnTypeForm, "formBundleNo", 2015, editAllowed = true, Some("backLink"))
 
       val document = Jsoup.parse(html.toString())
       Then("the page title : Have you disposed of the property?")

--- a/test/views/editLiability/editLiabilitySummarySpec.scala
+++ b/test/views/editLiability/editLiabilitySummarySpec.scala
@@ -57,7 +57,7 @@ class editLiabilitySummarySpec extends FeatureSpec with GuiceOneServerPerSuite w
       val displayPeriods = PeriodUtils.getDisplayPeriods(propertyDetails.period)
       assert(displayPeriods.size === 2)
       val html = views.html.editLiability.editLiabilitySummary(propertyDetails, "A", displayPeriods,
-        PeriodUtils.getCalculatedPeriodValues(propertyDetails.calculated), None)
+        PeriodUtils.getCalculatedPeriodValues(propertyDetails.calculated), Some("backLink"))
 
       val document = Jsoup.parse(html.toString())
 

--- a/test/views/formBundleReturnSpec.scala
+++ b/test/views/formBundleReturnSpec.scala
@@ -84,7 +84,7 @@ class formBundleReturnSpec extends FeatureSpec with GuiceOneServerPerSuite with 
       Then("The config should have - 2 periods")
       val displayPeriods = PeriodUtils.getDisplayPeriods(propertyDetails.period)
       assert(displayPeriods.size === 2)
-      val html = views.html.formBundleReturn(2015, None, "formBundleNo", Some("ACME Ltd"), changeAllowed = false, editAllowed = false, Nil, Nil, None)
+      val html = views.html.formBundleReturn(2015, None, "formBundleNo", Some("ACME Ltd"), changeAllowed = false, editAllowed = false, Nil, Nil, Some("backLink"))
 
       val document = Jsoup.parse(html.toString())
 

--- a/test/views/periodSummaryPastReturnsSpec.scala
+++ b/test/views/periodSummaryPastReturnsSpec.scala
@@ -62,7 +62,7 @@ class periodSummaryPastReturnsSpec extends FeatureSpec with GuiceOneServerPerSui
       Given("the client has no returns")
       When("The user views the page")
 
-      val html = views.html.periodSummaryPastReturns(2015, None, None, None)
+      val html = views.html.periodSummaryPastReturns(2015, None, None, Some("backLink"))
 
       val document = Jsoup.parse(html.toString())
 

--- a/test/views/periodSummarySpec.scala
+++ b/test/views/periodSummarySpec.scala
@@ -64,7 +64,7 @@ class periodSummarySpec extends FeatureSpec with GuiceOneAppPerSuite with Mockit
       Given("the client has no returns")
       When("The user views the page")
 
-      val html = views.html.periodSummary(2015, None, None, None)
+      val html = views.html.periodSummary(2015, None, None, Some("backLink"))
 
       val document = Jsoup.parse(html.toString())
 

--- a/test/views/propertyDetails/PropertyDetailsAddressSpec.scala
+++ b/test/views/propertyDetails/PropertyDetailsAddressSpec.scala
@@ -48,7 +48,7 @@ class PropertyDetailsAddressSpec extends FeatureSpec with GuiceOneServerPerSuite
       implicit val request = FakeRequest()
 
       val html = views.html.propertyDetails.propertyDetailsAddress(
-        None, 2015, propertyDetailsAddressForm, None, None, fromConfirmAddressPage = false)
+        None, 2015, propertyDetailsAddressForm, None, Some("backLink"), fromConfirmAddressPage = false)
 
       val document = Jsoup.parse(html.toString())
       Then("Enter your property details")

--- a/test/views/propertyDetails/PropertyDetailsRevaluedViewSpec.scala
+++ b/test/views/propertyDetails/PropertyDetailsRevaluedViewSpec.scala
@@ -48,7 +48,7 @@ class PropertyDetailsRevaluedViewSpec extends FeatureSpec with GuiceOneAppPerSui
 
       implicit val request = FakeRequest()
 
-      val html = views.html.propertyDetails.propertyDetailsRevalued("1", 2015, propertyDetailsRevaluedForm, None, None)
+      val html = views.html.propertyDetails.propertyDetailsRevalued("1", 2015, propertyDetailsRevaluedForm, None, Some("backLink"))
 
       val document = Jsoup.parse(html.toString())
       Then("the page title : Have you had the property revalued since you made the £40,000 change?")
@@ -147,7 +147,7 @@ class PropertyDetailsRevaluedViewSpec extends FeatureSpec with GuiceOneAppPerSui
           revaluedDate = None,
           partAcqDispDate = None)
 
-        val html = views.html.propertyDetails.propertyDetailsRevalued("1", 2015, propertyDetailsRevaluedForm.fill(propertyDetailsRevalued), None, None)
+        val html = views.html.propertyDetails.propertyDetailsRevalued("1", 2015, propertyDetailsRevaluedForm.fill(propertyDetailsRevalued), None, Some("backLink"))
 
         val document = Jsoup.parse(html.toString())
         Then("the page title : Have you had the property revalued since you made the £40,000 change?")

--- a/test/views/propertyDetails/addressLookupResultsSpec.scala
+++ b/test/views/propertyDetails/addressLookupResultsSpec.scala
@@ -46,7 +46,7 @@ class addressLookupResultsSpec extends FeatureSpec with GuiceOneAppPerSuite with
       implicit val request = FakeRequest()
 
       val results = AddressSearchResults(searchCriteria = AddressLookup("XX1 1XX", None), Nil)
-      val html = views.html.propertyDetails.addressLookupResults(None, 2015, addressSelectedForm, results, None, None)
+      val html = views.html.propertyDetails.addressLookupResults(None, 2015, addressSelectedForm, results, None, Some("backLink"))
 
       val document = Jsoup.parse(html.toString())
       Then("Select the address of the property")

--- a/test/views/propertyDetails/addressLookupSpec.scala
+++ b/test/views/propertyDetails/addressLookupSpec.scala
@@ -46,7 +46,7 @@ class addressLookupSpec extends FeatureSpec with GuiceOneAppPerSuite with Mockit
       When("The user views the page")
       implicit val request = FakeRequest()
 
-      val html = views.html.propertyDetails.addressLookup(None, 2015, addressLookupForm, None, None)
+      val html = views.html.propertyDetails.addressLookup(None, 2015, addressLookupForm, None, Some("backLink"))
 
       val document = Jsoup.parse(html.toString())
       Then("The title and header should match - Find the property's address")

--- a/test/views/propertyDetails/periodChooseReliefSpec.scala
+++ b/test/views/propertyDetails/periodChooseReliefSpec.scala
@@ -48,7 +48,7 @@ class periodChooseReliefSpec extends FeatureSpec with GuiceOneAppPerSuite with M
 
       val periodStartDate = new LocalDate("2015-01-01")
       val periodEndDate = new LocalDate("2016-02-02")
-      val html = views.html.propertyDetails.periodChooseRelief("1", 2015, periodChooseReliefForm, None)
+      val html = views.html.propertyDetails.periodChooseRelief("1", 2015, periodChooseReliefForm, Some("backLink"))
 
       val document = Jsoup.parse(html.toString())
 

--- a/test/views/propertyDetails/periodDatesLiableSpec.scala
+++ b/test/views/propertyDetails/periodDatesLiableSpec.scala
@@ -45,7 +45,7 @@ class periodDatesLiableSpec extends FeatureSpec with GuiceOneAppPerSuite with Mo
       When("The user views the page")
 
       val html = views.html.propertyDetails.periodDatesLiable("1", 2015, periodDatesLiableForm,
-        "Enter the dates when the property was liable for an ATED charge", None, None)
+        "Enter the dates when the property was liable for an ATED charge", None, Some("backLink"))
 
       val document = Jsoup.parse(html.toString())
 

--- a/test/views/propertyDetails/periodsInAndOutReliefSpec.scala
+++ b/test/views/propertyDetails/periodsInAndOutReliefSpec.scala
@@ -46,7 +46,7 @@ class periodsInAndOutReliefSpec extends FeatureSpec with GuiceOneAppPerSuite wit
       Given("the client is creating a new liability and want to add multiple periods")
       When("The user views the page")
 
-      val html = views.html.propertyDetails.periodsInAndOutRelief("1", 2015, periodsInAndOutReliefForm, Nil, None, None)
+      val html = views.html.propertyDetails.periodsInAndOutRelief("1", 2015, periodsInAndOutReliefForm, Nil, None, Some("backLink"))
 
       val document = Jsoup.parse(html.toString())
 

--- a/test/views/propertyDetails/propertyDetailsTitleSpec.scala
+++ b/test/views/propertyDetails/propertyDetailsTitleSpec.scala
@@ -44,7 +44,7 @@ class propertyDetailsTitleSpec extends FeatureSpec with GuiceOneAppPerSuite with
       Given("the client is adding a dates liable")
       When("The user views the page")
 
-      val html = views.html.propertyDetails.propertyDetailsTitle("1", 2015, propertyDetailsTitleForm, None, None)
+      val html = views.html.propertyDetails.propertyDetailsTitle("1", 2015, propertyDetailsTitleForm, None, Some("backLink"))
 
       val document = Jsoup.parse(html.toString())
 

--- a/test/views/reliefs/ReliefDeclarationSpec.scala
+++ b/test/views/reliefs/ReliefDeclarationSpec.scala
@@ -44,7 +44,7 @@ class ReliefDeclarationSpec extends FeatureSpec with GuiceOneAppPerSuite with Mo
       When("The user views the page")
 
 
-      val html = views.html.reliefs.reliefDeclaration(2015, None)
+      val html = views.html.reliefs.reliefDeclaration(2015, Some("backLink"))
 
       val document = Jsoup.parse(html.toString())
 

--- a/test/views/reliefs/changeReliefReturnSpec.scala
+++ b/test/views/reliefs/changeReliefReturnSpec.scala
@@ -44,7 +44,7 @@ class changeReliefReturnSpec extends FeatureSpec with GuiceOneAppPerSuite with M
       Given("the client has clicked change on a relief")
       When("The user views the page")
 
-      val html = views.html.reliefs.changeReliefReturn(2015, "form-bundle-123", editReliefForm, None)
+      val html = views.html.reliefs.changeReliefReturn(2015, "form-bundle-123", editReliefForm, Some("backLink"))
 
       val document = Jsoup.parse(html.toString())
 

--- a/test/views/reliefs/chooseReliefsSpec.scala
+++ b/test/views/reliefs/chooseReliefsSpec.scala
@@ -48,7 +48,7 @@ class chooseReliefsSpec extends FeatureSpec with GuiceOneAppPerSuite with Mockit
       Given("the client is creating a new relief and want to see the options")
       When("The user views the page")
 
-      val html = views.html.reliefs.chooseReliefs(periodKey, reliefsForm, new LocalDate("2015-04-01"), None)
+      val html = views.html.reliefs.chooseReliefs(periodKey, reliefsForm, new LocalDate("2015-04-01"), Some("backLink"))
 
       val document = Jsoup.parse(html.toString())
 

--- a/test/views/reliefs/isAvoidanceSchemeSpec.scala
+++ b/test/views/reliefs/isAvoidanceSchemeSpec.scala
@@ -47,7 +47,7 @@ class isAvoidanceSchemeSpec extends FeatureSpec with GuiceOneAppPerSuite
       Given("the client is creating a new relief and want tell us if an avoidance scheme is being used")
       When("The user views the page")
 
-      val html = views.html.reliefs.avoidanceSchemeBeingUsed(periodKey, isTaxAvoidanceForm , new LocalDate("2015-04-01"), None)
+      val html = views.html.reliefs.avoidanceSchemeBeingUsed(periodKey, isTaxAvoidanceForm , new LocalDate("2015-04-01"), Some("backLink"))
 
       val document = Jsoup.parse(html.toString())
 


### PR DESCRIPTION
amend pageHeadersAndError to only display backlink where defined

**Bug fix** 

Updated pageHeadersAndError to not display the back link on views where it was not defined or defined as None in relevant view.

Fixing tests which where previously setting backlink as None and verifying that it existed on page

## Checklist

*Reviewee* (Replace with your name)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [x]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date