### PR TITLE
DL-2623 Repeated relief codes in current returns

### DIFF
--- a/app/controllers/PeriodSummaryController.scala
+++ b/app/controllers/PeriodSummaryController.scala
@@ -47,7 +47,8 @@ class PeriodSummaryController @Inject()(mcc: MessagesControllerComponents,
         periodSummaries <- summaryReturnsService.getPeriodSummaryReturns(periodKey)
         organisationName <- subscriptionDataService.getOrganisationName
       } yield {
-        Ok(views.html.periodSummary(periodKey, periodSummaries, organisationName, getBackLink()))
+        val filteredSummaries = periodSummaries.map(summaryReturnsService.filterPeriodSummaryReturnReliefs(_, past = false))
+        Ok(views.html.periodSummary(periodKey, filteredSummaries, organisationName, getBackLink()))
       }
     }
   }
@@ -58,7 +59,8 @@ class PeriodSummaryController @Inject()(mcc: MessagesControllerComponents,
         periodSummaries <- summaryReturnsService.getPeriodSummaryReturns(periodKey)
         organisationName <- subscriptionDataService.getOrganisationName
       } yield {
-        Ok(views.html.periodSummaryPastReturns(periodKey, periodSummaries, organisationName, getBackLink()))
+        val filteredSummaries = periodSummaries.map(summaryReturnsService.filterPeriodSummaryReturnReliefs(_, past = true))
+        Ok(views.html.periodSummaryPastReturns(periodKey, filteredSummaries, organisationName, getBackLink()))
       }
     }
   }

--- a/app/controllers/reliefs/ViewReliefReturnController.scala
+++ b/app/controllers/reliefs/ViewReliefReturnController.scala
@@ -47,11 +47,11 @@ class ViewReliefReturnController @Inject()(mcc: MessagesControllerComponents,
         val formBundleReturnFuture = reliefsService.viewReliefReturn(periodKey, formBundleNo)
         val organisationNameFuture = subscriptionDataService.getOrganisationName
         for {
-          formBundleReturn <- formBundleReturnFuture
+          (formBundleReturn, isEditable) <- formBundleReturnFuture
           organisationName <- organisationNameFuture
         } yield {
           formBundleReturn match {
-            case Some(x) => Ok(views.html.reliefs.viewReliefReturn(x, periodKey, formBundleNo, organisationName,
+            case Some(x) => Ok(views.html.reliefs.viewReliefReturn(x, periodKey, formBundleNo, organisationName, isEditable,
               Some(controllers.routes.PeriodSummaryController.view(periodKey).url)))
             case None => throw new RuntimeException("No reliefs found in the cache for provided period and form bundle id")
           }

--- a/app/views/periodSummary.scala.html
+++ b/app/views/periodSummary.scala.html
@@ -16,6 +16,7 @@
 
 @import models._
 @import config.ApplicationConfig
+@import _root_.utils.ReliefsUtils
 @(periodKey: Int, periodSummaries: Option[PeriodSummaryReturns],
   organisationName: Option[String],
   backLink: Option[String])(implicit authContext: StandardAuthRetrievals, messages: Messages, request: Request[AnyContent], appConfig: ApplicationConfig)
@@ -41,7 +42,7 @@ periodEndDate(periodKey).toString(Messages("ated.date-format.summary"))), subHea
     <li id="current-returns" class="selected heading-small" role="tab">
       @Messages("ated.period-summary.tabs.current-returns")
     </li>
-    @if(periodSummaries.flatMap(_.submittedReturns.map(_.oldLiabilityReturns.isEmpty)) == Some(false)) {
+    @if(periodSummaries.flatMap(_.submittedReturns.map(_.oldLiabilityReturns.isEmpty)).contains(false)) {
     <li id="past-returns" class="heading-small" role="tab">
       <a href="@controllers.routes.PeriodSummaryController.viewPastReturns(periodKey)" id="past-returns-link" data-journey-click="ated:click:past-returns">
         @Messages("ated.period-summary.tabs.past-returns")

--- a/app/views/periodSummaryPastReturns.scala.html
+++ b/app/views/periodSummaryPastReturns.scala.html
@@ -16,6 +16,7 @@
 
 @import models._
 @import config.ApplicationConfig
+@import _root_.utils.ReliefsUtils
 @(periodKey: Int, periodSummaries: Option[PeriodSummaryReturns],
   organisationName: Option[String],
   backLink: Option[String])(implicit authContext: StandardAuthRetrievals, messages: Messages, request: Request[AnyContent], appConfig: ApplicationConfig)
@@ -82,6 +83,28 @@ periodEndDate(periodKey).toString(Messages("ated.date-format.summary"))), subHea
           </div>
 
         } @*liability-returns end*@
+
+          <div class="form-group">
+          @b.reliefReturns.zipWithIndex.map { t =>
+              <div class="grid-wrapper row-border">
+                  <div class="grid grid-1-2 psp-return">
+                      <span class="visuallyhidden">@Messages("ated.period-summary.sr.relieftype")</span>
+                      @t._1.reliefType
+                  </div>
+
+                  <div class="grid grid-1-4 psp-status">
+                      <span class="visuallyhidden">@Messages("ated.period-summary-th.status")</span>
+                      @Messages("ated.submitted")
+                  </div>
+
+                  <div class="grid grid-1-4 psp-action">
+                      <a id="relief-submitted-@t._2" href='@controllers.reliefs.routes.ViewReliefReturnController.viewReliefReturn(periodKey, t._1.formBundleNo)'
+                      data-journey-click="ated-fronted:click:liability-submitted">
+                          @Messages("ated.period-summary.view.button") <span class="visuallyhidden">@Messages("ated.period-summary.sr.return") @t._1.reliefType</span>
+                      </a>
+                  </div>
+              </div>
+          }
       } @*all submitted returns end*@
     }
 

--- a/app/views/reliefs/viewReliefReturn.scala.html
+++ b/app/views/reliefs/viewReliefReturn.scala.html
@@ -16,7 +16,7 @@
 
 @import models._
 @import config.ApplicationConfig
-@(submittedReliefReturn: SubmittedReliefReturns, periodKey: Int, formBundleNumber: String, organisationName: Option[String], backLink: Option[String])(implicit authContext: StandardAuthRetrievals, messages: Messages, request: Request[AnyContent], appConfig: ApplicationConfig)
+@(submittedReliefReturn: SubmittedReliefReturns, periodKey: Int, formBundleNumber: String, organisationName: Option[String], isEditable: Boolean, backLink: Option[String])(implicit authContext: StandardAuthRetrievals, messages: Messages, request: Request[AnyContent], appConfig: ApplicationConfig)
 @import uk.gov.hmrc.play.views.html._
 @import uk.gov.hmrc.play.views.html.helpers._
 @import views.html.helpers._
@@ -125,8 +125,9 @@
       </span>
     </div>
 
-
-      <button class="button" id="submit" type="submit">@Messages("ated.change-return.button")</button>
+    @if(isEditable) {
+        <button class="button" id="submit" type="submit">@Messages("ated.change-return.button")</button>
+    }
 
 
 }

--- a/test/controllers/PeriodSummaryControllerSpec.scala
+++ b/test/controllers/PeriodSummaryControllerSpec.scala
@@ -93,6 +93,11 @@ class PeriodSummaryControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
       setAuthMocks(authMock)
       when(mockSummaryReturnsService.getPeriodSummaryReturns(ArgumentMatchers.eq(period))(ArgumentMatchers.any(), ArgumentMatchers.any()))
         .thenReturn(Future.successful(periodSummaries))
+
+      periodSummaries.foreach{periodSum =>
+        when(mockSummaryReturnsService.filterPeriodSummaryReturnReliefs(periodSum, past = false))
+      }
+
       when(mockSubscriptionDataService.getOrganisationName(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some(organisationName)))
 
       val result = testPeriodSummaryController.view(periodKey).apply(SessionBuilder.buildRequestWithSession(userId))

--- a/test/services/ReliefsServiceSpec.scala
+++ b/test/services/ReliefsServiceSpec.scala
@@ -397,8 +397,8 @@ class ReliefsServiceSpec extends PlaySpec with MockitoSugar with PrivateMethodTe
         when(mockDataCacheConnector.fetchAndGetFormData[SummaryReturnsModel](ArgumentMatchers.eq(RetrieveReturnsResponseId))(any(), any(), any()))
           .thenReturn(Future.successful(Some(data)))
 
-        val result: Future[Option[SubmittedReliefReturns]] = testReliefsService.viewReliefReturn(periodKey, formBundleNo1)
-        await(result) must be(Some(submittedReliefReturns1))
+        val result: Future[(Option[SubmittedReliefReturns], Boolean)] = testReliefsService.viewReliefReturn(periodKey, formBundleNo1)
+        await(result) must be(Some(submittedReliefReturns1), true)
       }
 
       "if summary data is found in Cache, but relief return  is None, return None" in new Setup {
@@ -413,8 +413,8 @@ class ReliefsServiceSpec extends PlaySpec with MockitoSugar with PrivateMethodTe
         when(mockDataCacheConnector.fetchAndGetFormData[SummaryReturnsModel](ArgumentMatchers.eq(RetrieveReturnsResponseId))(any(), any(), any()))
           .thenReturn(Future.successful(Some(data)))
 
-        val result: Future[Option[SubmittedReliefReturns]] = testReliefsService.viewReliefReturn(periodKey, formBundleNo1)
-        await(result) must be(None)
+        val result: Future[(Option[SubmittedReliefReturns], Boolean)] = testReliefsService.viewReliefReturn(periodKey, formBundleNo1)
+        await(result) must be(None, false)
       }
       "if summary data is found in Cache, but it doesn't contain EtmpResponseWrapper, return None" in new Setup {
         implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId(s"session-${UUID.randomUUID}")))
@@ -424,8 +424,8 @@ class ReliefsServiceSpec extends PlaySpec with MockitoSugar with PrivateMethodTe
         when(mockDataCacheConnector.fetchAndGetFormData[SummaryReturnsModel](ArgumentMatchers.eq(RetrieveReturnsResponseId))(any(), any(), any()))
           .thenReturn(Future.successful(Some(data)))
 
-        val result: Future[Option[SubmittedReliefReturns]] = testReliefsService.viewReliefReturn(periodKey, formBundleNo)
-        await(result) must be(None)
+        val result: Future[(Option[SubmittedReliefReturns], Boolean)] = testReliefsService.viewReliefReturn(periodKey, formBundleNo)
+        await(result) must be(None, false)
       }
       "if no summary data is found in Cache, return None" in new Setup {
         implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId(s"session-${UUID.randomUUID}")))
@@ -434,8 +434,8 @@ class ReliefsServiceSpec extends PlaySpec with MockitoSugar with PrivateMethodTe
         when(mockDataCacheConnector.fetchAndGetFormData[SummaryReturnsModel](ArgumentMatchers.eq(RetrieveReturnsResponseId))(any(), any(), any()))
           .thenReturn(Future.successful(None))
 
-        val result: Future[Option[SubmittedReliefReturns]] = testReliefsService.viewReliefReturn(periodKey, formBundleNo)
-        await(result) must be(None)
+        val result: Future[(Option[SubmittedReliefReturns], Boolean)] = testReliefsService.viewReliefReturn(periodKey, formBundleNo)
+        await(result) must be(None, false)
       }
     }
 

--- a/test/services/SummaryReturnsServiceSpec.scala
+++ b/test/services/SummaryReturnsServiceSpec.scala
@@ -246,5 +246,46 @@ class SummaryReturnsServiceSpec extends PlaySpec with MockitoSugar with BeforeAn
           4, false)
       }
     }
+
+    "filterPeriodSummaryReturnReliefs" must {
+      "filter out unwanted reliefs in the past" in new Setup {
+        val newerType1Return = SubmittedReliefReturns("no1", "type 1", LocalDate.now(), LocalDate.now(), LocalDate.now().minusDays(1))
+        val olderType1Return = SubmittedReliefReturns("no2", "type 1", LocalDate.now(), LocalDate.now(), LocalDate.now().minusDays(2))
+        val older2Type1Return = SubmittedReliefReturns("no3", "type 1", LocalDate.now(), LocalDate.now(), LocalDate.now().minusDays(3))
+
+        val submittedReturns = SubmittedReturns(
+          2018, Seq(newerType1Return, older2Type1Return, olderType1Return)
+        )
+        val periodSummaryReturns = PeriodSummaryReturns(
+          2018,
+          Nil,
+          Some(submittedReturns)
+        )
+
+        val result = testSummaryReturnsService.filterPeriodSummaryReturnReliefs(periodSummaryReturns, true)
+
+        result.submittedReturns.get.reliefReturns.contains(olderType1Return) mustBe true
+        result.submittedReturns.get.reliefReturns.contains(older2Type1Return) mustBe true
+      }
+
+      "filter out unwanted reliefs for the current reliefs" in new Setup {
+        val newerType1Return = SubmittedReliefReturns("no1", "type 1", LocalDate.now(), LocalDate.now(), LocalDate.now().minusDays(1))
+        val olderType1Return = SubmittedReliefReturns("no2", "type 1", LocalDate.now(), LocalDate.now(), LocalDate.now().minusDays(2))
+        val older2Type1Return = SubmittedReliefReturns("no3", "type 1", LocalDate.now(), LocalDate.now(), LocalDate.now().minusDays(3))
+
+        val submittedReturns = SubmittedReturns(
+          2018, Seq(newerType1Return, older2Type1Return, olderType1Return)
+        )
+        val periodSummaryReturns = PeriodSummaryReturns(
+          2018,
+          Nil,
+          Some(submittedReturns)
+        )
+
+        val result = testSummaryReturnsService.filterPeriodSummaryReturnReliefs(periodSummaryReturns, false)
+
+        result.submittedReturns.get.reliefReturns.contains(newerType1Return) mustBe true
+      }
+    }
   }
 }

--- a/test/views/periodSummaryPastReturnsSpec.scala
+++ b/test/views/periodSummaryPastReturnsSpec.scala
@@ -44,12 +44,14 @@ class periodSummaryPastReturnsSpec extends FeatureSpec with GuiceOneServerPerSui
   val draftReturns2: DraftReturns = DraftReturns(2015, "", "some relief", None, TypeReliefDraft)
   val submittedReliefReturns1: SubmittedReliefReturns = SubmittedReliefReturns(formBundleNo1, "some relief",
     new LocalDate("2015-05-05"), new LocalDate("2015-05-05"), new LocalDate("2015-05-05"))
+  val submittedReliefReturns1Older = SubmittedReliefReturns(formBundleNo1, "some relief",
+    new LocalDate("2015-05-05"), new LocalDate("2015-05-05"), new LocalDate("2015-04-05"))
   val submittedLiabilityReturns1 = SubmittedLiabilityReturns(formBundleNo2, "addr1+2", BigDecimal(1234.00),
     new LocalDate("2015-05-05"), new LocalDate("2015-05-05"), new LocalDate("2015-05-05"), changeAllowed = true, "payment-ref-01")
   val submittedLiabilityReturns2 = SubmittedLiabilityReturns(formBundleNo3, "addr1+2", BigDecimal(1234.00),
     new LocalDate("2015-05-05"), new LocalDate("2015-05-05"), new LocalDate("2015-06-06"), changeAllowed = true, "payment-ref-01")
 
-  val submittedReturns = SubmittedReturns(2015, Seq(submittedReliefReturns1), Seq(submittedLiabilityReturns1))
+  val submittedReturns = SubmittedReturns(2015, Seq(submittedReliefReturns1, submittedReliefReturns1Older), Seq(submittedLiabilityReturns1))
   val submittedReturnsWithOld = SubmittedReturns(2015, Seq(submittedReliefReturns1), Seq(submittedLiabilityReturns1), Seq(submittedLiabilityReturns2))
   val periodSummaryReturns = PeriodSummaryReturns(2015, Seq(draftReturns1, draftReturns2), Some(submittedReturns))
   val periodSummaryReturnsWithOld = PeriodSummaryReturns(2015, Seq(draftReturns1, draftReturns2), Some(submittedReturnsWithOld))
@@ -105,6 +107,8 @@ class periodSummaryPastReturnsSpec extends FeatureSpec with GuiceOneServerPerSui
       Then("The table should have data")
       assert(document.getElementById("view-edit-0") === null)
       assert(document.getElementById("liability-submitted-0") === null)
+
+      assert(document.getElementById("relief-submitted-0").text() === "View return, some relief")
 
       assert(document.getElementById("backLinkHref").text() === "Back")
       assert(document.getElementById("backLinkHref").attr("href") === "http://backlink")

--- a/test/views/periodSummarySpec.scala
+++ b/test/views/periodSummarySpec.scala
@@ -46,12 +46,14 @@ class periodSummarySpec extends FeatureSpec with GuiceOneAppPerSuite with Mockit
   val draftReturns2 = DraftReturns(2015, "", "some relief", None, TypeReliefDraft)
   val submittedReliefReturns1 = SubmittedReliefReturns(formBundleNo1, "some relief",
     new LocalDate("2015-05-05"), new LocalDate("2015-05-05"), new LocalDate("2015-05-05"))
+  val submittedReliefReturns1Older = SubmittedReliefReturns(formBundleNo1, "some relief",
+    new LocalDate("2015-05-05"), new LocalDate("2015-05-05"), new LocalDate("2015-04-05"))
   val submittedLiabilityReturns1 = SubmittedLiabilityReturns(formBundleNo2, "addr1+2", BigDecimal(1234.00),
     new LocalDate("2015-05-05"), new LocalDate("2015-05-05"), new LocalDate("2015-05-05"), changeAllowed = true, "payment-ref-01")
   val submittedLiabilityReturns2 = SubmittedLiabilityReturns(formBundleNo3, "addr1+2", BigDecimal(1234.00),
     new LocalDate("2015-05-05"), new LocalDate("2015-05-05"), new LocalDate("2015-06-06"), changeAllowed = true, "payment-ref-01")
 
-  val submittedReturns = SubmittedReturns(2015, Seq(submittedReliefReturns1), Seq(submittedLiabilityReturns1))
+  val submittedReturns = SubmittedReturns(2015, Seq(submittedReliefReturns1, submittedReliefReturns1Older), Seq(submittedLiabilityReturns1))
   val submittedReturnsWithOld = SubmittedReturns(2015, Seq(submittedReliefReturns1), Seq(submittedLiabilityReturns1), Seq(submittedLiabilityReturns2))
   val periodSummaryReturns = PeriodSummaryReturns(2015, Seq(draftReturns1, draftReturns2), Some(submittedReturns))
   val periodSummaryReturnsWithOld = PeriodSummaryReturns(2015, Seq(draftReturns1, draftReturns2), Some(submittedReturnsWithOld))


### PR DESCRIPTION
# DL-2623 Repeated relief codes in current returns

**Bug fix**

* Submitted repeated relief codes, if the relief is a day or older, no longer appear twice on the current returns tab - they have now been moved to the 

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date