### PR TITLE
Fix for summary calculation error where data missing

### DIFF
--- a/test/connectors/AddressLookupConnectorSpec.scala
+++ b/test/connectors/AddressLookupConnectorSpec.scala
@@ -24,7 +24,7 @@ import models._
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.test.Helpers._

--- a/test/connectors/AgentClientMandateFrontendConnectorSpec.scala
+++ b/test/connectors/AgentClientMandateFrontendConnectorSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.mvc.AnyContentAsEmpty

--- a/test/connectors/AtedConnectorSpec.scala
+++ b/test/connectors/AtedConnectorSpec.scala
@@ -25,7 +25,7 @@ import models._
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/connectors/BackLinkCacheConnectorSpec.scala
+++ b/test/connectors/BackLinkCacheConnectorSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import models.BackLinkModel
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.Json

--- a/test/connectors/DataCacheConnectorSpec.scala
+++ b/test/connectors/DataCacheConnectorSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import models.{ReturnType, StandardAuthRetrievals}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.{JsString, JsValue, Json}

--- a/test/connectors/DelegationConnectorSpec.scala
+++ b/test/connectors/DelegationConnectorSpec.scala
@@ -19,7 +19,7 @@ package connectors
 import config.ApplicationConfig
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.JsValue

--- a/test/connectors/PropertyDetailsConnectorSpec.scala
+++ b/test/connectors/PropertyDetailsConnectorSpec.scala
@@ -25,7 +25,7 @@ import org.joda.time.LocalDate
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/AccountSummaryControllerSpec.scala
+++ b/test/controllers/AccountSummaryControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/ApplicationControllerSpec.scala
+++ b/test/controllers/ApplicationControllerSpec.scala
@@ -23,7 +23,7 @@ import config.ApplicationConfig
 import controllers.auth.AuthAction
 import testhelpers.MockAuthUtil
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/DraftDeleteConfirmationControllerSpec.scala
+++ b/test/controllers/DraftDeleteConfirmationControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/ExistingReturnQuestionControllerSpec.scala
+++ b/test/controllers/ExistingReturnQuestionControllerSpec.scala
@@ -44,7 +44,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/FormBundleReturnControllerSpec.scala
+++ b/test/controllers/FormBundleReturnControllerSpec.scala
@@ -29,7 +29,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/HomeControllerSpec.scala
+++ b/test/controllers/HomeControllerSpec.scala
@@ -23,7 +23,7 @@ import config.ApplicationConfig
 import controllers.auth.AuthAction
 import testhelpers.MockAuthUtil
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/LeaveFeedbackControllerSpec.scala
+++ b/test/controllers/LeaveFeedbackControllerSpec.scala
@@ -25,7 +25,7 @@ import controllers.auth.AuthAction
 import testhelpers.MockAuthUtil
 import org.jsoup.Jsoup
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/PeriodSummaryControllerSpec.scala
+++ b/test/controllers/PeriodSummaryControllerSpec.scala
@@ -31,7 +31,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/PrevPeriodsSummaryControllerSpec.scala
+++ b/test/controllers/PrevPeriodsSummaryControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/ReturnTypeControllerSpec.scala
+++ b/test/controllers/ReturnTypeControllerSpec.scala
@@ -31,7 +31,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/SelectPeriodControllerSpec.scala
+++ b/test/controllers/SelectPeriodControllerSpec.scala
@@ -28,7 +28,7 @@ import org.joda.time.LocalDate
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/auth/AuthActionSpec.scala
+++ b/test/controllers/auth/AuthActionSpec.scala
@@ -22,7 +22,7 @@ import models.StandardAuthRetrievals
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, _}
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.{Messages, MessagesApi}
 import play.api.mvc.{AnyContentAsEmpty, Result, Results}
 import play.api.test.Helpers.redirectLocation

--- a/test/controllers/auth/ExternalUrlsSpec.scala
+++ b/test/controllers/auth/ExternalUrlsSpec.scala
@@ -17,7 +17,7 @@
 package controllers.auth
 
 import config.ApplicationConfig
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 

--- a/test/controllers/editLiability/BankDetailsControllerSpec.scala
+++ b/test/controllers/editLiability/BankDetailsControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/editLiability/DisposeLiabilityBankDetailsControllerSpec.scala
+++ b/test/controllers/editLiability/DisposeLiabilityBankDetailsControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/editLiability/DisposeLiabilityDeclarationControllerSpec.scala
+++ b/test/controllers/editLiability/DisposeLiabilityDeclarationControllerSpec.scala
@@ -29,7 +29,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/editLiability/DisposeLiabilityHasBankDetailsControllerSpec.scala
+++ b/test/controllers/editLiability/DisposeLiabilityHasBankDetailsControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/editLiability/DisposeLiabilitySentControllerSpec.scala
+++ b/test/controllers/editLiability/DisposeLiabilitySentControllerSpec.scala
@@ -30,7 +30,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.{reset, _}
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/editLiability/DisposeLiabilitySummaryControllerSpec.scala
+++ b/test/controllers/editLiability/DisposeLiabilitySummaryControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/editLiability/DisposePropertyControllerSpec.scala
+++ b/test/controllers/editLiability/DisposePropertyControllerSpec.scala
@@ -29,7 +29,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/editLiability/EditLiabilityDatesLiableControllerSpec.scala
+++ b/test/controllers/editLiability/EditLiabilityDatesLiableControllerSpec.scala
@@ -30,7 +30,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/editLiability/EditLiabilityDeclarationControllerSpec.scala
+++ b/test/controllers/editLiability/EditLiabilityDeclarationControllerSpec.scala
@@ -29,7 +29,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/editLiability/EditLiabilityHasValueChangedControllerSpec.scala
+++ b/test/controllers/editLiability/EditLiabilityHasValueChangedControllerSpec.scala
@@ -29,7 +29,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/editLiability/EditLiabilitySentControllerSpec.scala
+++ b/test/controllers/editLiability/EditLiabilitySentControllerSpec.scala
@@ -30,7 +30,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/editLiability/EditLiabilityTypeControllerSpec.scala
+++ b/test/controllers/editLiability/EditLiabilityTypeControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.Json

--- a/test/controllers/editLiability/HasBankDetailsControllerSpec.scala
+++ b/test/controllers/editLiability/HasBankDetailsControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/propertyDetails/AddressLookupControllerSpec.scala
+++ b/test/controllers/propertyDetails/AddressLookupControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/propertyDetails/ChargeableReturnConfirmationControllerSpec.scala
+++ b/test/controllers/propertyDetails/ChargeableReturnConfirmationControllerSpec.scala
@@ -29,7 +29,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/propertyDetails/ConfirmAddressControllerSpec.scala
+++ b/test/controllers/propertyDetails/ConfirmAddressControllerSpec.scala
@@ -27,7 +27,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.when
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/propertyDetails/IsFullTaxPeriodControllerSpec.scala
+++ b/test/controllers/propertyDetails/IsFullTaxPeriodControllerSpec.scala
@@ -29,7 +29,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/propertyDetails/PeriodChooseReliefsControllerSpec.scala
+++ b/test/controllers/propertyDetails/PeriodChooseReliefsControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/propertyDetails/PeriodDatesLiableControllerSpec.scala
+++ b/test/controllers/propertyDetails/PeriodDatesLiableControllerSpec.scala
@@ -29,7 +29,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/propertyDetails/PeriodInReliefDatesControllerSpec.scala
+++ b/test/controllers/propertyDetails/PeriodInReliefDatesControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/propertyDetails/PeriodsInAndOutReliefControllerSpec.scala
+++ b/test/controllers/propertyDetails/PeriodsInAndOutReliefControllerSpec.scala
@@ -29,7 +29,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/propertyDetails/PropertyDetailsAcquisitionControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsAcquisitionControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/propertyDetails/PropertyDetailsAddressControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsAddressControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/propertyDetails/PropertyDetailsDeclarationControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsDeclarationControllerSpec.scala
@@ -27,7 +27,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/propertyDetails/PropertyDetailsHelperSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsHelperSpec.scala
@@ -23,7 +23,7 @@ import models.StandardAuthRetrievals
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.PartialFunctionValues
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/propertyDetails/PropertyDetailsInReliefControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsInReliefControllerSpec.scala
@@ -30,7 +30,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/propertyDetails/PropertyDetailsNewBuildControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsNewBuildControllerSpec.scala
@@ -27,7 +27,7 @@ import models._
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/propertyDetails/PropertyDetailsOwnedBeforeControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsOwnedBeforeControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/propertyDetails/PropertyDetailsProfessionallyValuedControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsProfessionallyValuedControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/propertyDetails/PropertyDetailsRevaluedControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsRevaluedControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/propertyDetails/PropertyDetailsSummaryControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsSummaryControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.Json

--- a/test/controllers/propertyDetails/PropertyDetailsSupportingInfoControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsSupportingInfoControllerSpec.scala
@@ -30,7 +30,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/propertyDetails/PropertyDetailsTaxAvoidanceControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsTaxAvoidanceControllerSpec.scala
@@ -29,7 +29,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/propertyDetails/PropertyDetailsTitleControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsTitleControllerSpec.scala
@@ -29,7 +29,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/propertyDetails/SelectExistingReturnAddressControllerSpec.scala
+++ b/test/controllers/propertyDetails/SelectExistingReturnAddressControllerSpec.scala
@@ -29,7 +29,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/reliefs/AvoidanceSchemeBeingUsedControllerSpec.scala
+++ b/test/controllers/reliefs/AvoidanceSchemeBeingUsedControllerSpec.scala
@@ -29,7 +29,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{AnyContentAsFormUrlEncoded, MessagesControllerComponents, Result}

--- a/test/controllers/reliefs/AvoidanceSchemesControllerSpec.scala
+++ b/test/controllers/reliefs/AvoidanceSchemesControllerSpec.scala
@@ -27,7 +27,7 @@ import models.{Reliefs, ReliefsTaxAvoidance, TaxAvoidance}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/reliefs/ChangeReliefReturnControllerSpec.scala
+++ b/test/controllers/reliefs/ChangeReliefReturnControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/reliefs/ChooseReliefsControllerSpec.scala
+++ b/test/controllers/reliefs/ChooseReliefsControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/reliefs/ReliefDeclarationControllerSpec.scala
+++ b/test/controllers/reliefs/ReliefDeclarationControllerSpec.scala
@@ -27,7 +27,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.Json

--- a/test/controllers/reliefs/ReliefsSentControllerSpec.scala
+++ b/test/controllers/reliefs/ReliefsSentControllerSpec.scala
@@ -30,7 +30,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/reliefs/ReliefsSummaryControllerSpec.scala
+++ b/test/controllers/reliefs/ReliefsSummaryControllerSpec.scala
@@ -29,7 +29,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/reliefs/ViewReliefReturnControllerSpec.scala
+++ b/test/controllers/reliefs/ViewReliefReturnControllerSpec.scala
@@ -29,7 +29,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/subscriptionData/CompanyDetailsControllerSpec.scala
+++ b/test/controllers/subscriptionData/CompanyDetailsControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.{MessagesControllerComponents, Result}

--- a/test/controllers/subscriptionData/CorrespondenceAddressControllerSpec.scala
+++ b/test/controllers/subscriptionData/CorrespondenceAddressControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Environment

--- a/test/controllers/subscriptionData/EditContactDetailsControllerSpec.scala
+++ b/test/controllers/subscriptionData/EditContactDetailsControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/subscriptionData/EditContactEmailControllerSpec.scala
+++ b/test/controllers/subscriptionData/EditContactEmailControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/controllers/subscriptionData/OverseasCompanyRegistrationControllerSpec.scala
+++ b/test/controllers/subscriptionData/OverseasCompanyRegistrationControllerSpec.scala
@@ -27,7 +27,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Environment

--- a/test/controllers/subscriptionData/RegisteredDetailsControllerSpec.scala
+++ b/test/controllers/subscriptionData/RegisteredDetailsControllerSpec.scala
@@ -28,7 +28,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Environment

--- a/test/services/AddressLookupServiceSpec.scala
+++ b/test/services/AddressLookupServiceSpec.scala
@@ -22,7 +22,7 @@ import models._
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.test.Helpers._

--- a/test/services/ChangeLiabilityReturnServiceSpec.scala
+++ b/test/services/ChangeLiabilityReturnServiceSpec.scala
@@ -22,7 +22,7 @@ import models._
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/services/DelegationServiceSpec.scala
+++ b/test/services/DelegationServiceSpec.scala
@@ -21,7 +21,7 @@ import models.{DelegationModel, Link, PrincipalTaxIdentifiers}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.{reset, _}
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}

--- a/test/services/DetailsServiceSpec.scala
+++ b/test/services/DetailsServiceSpec.scala
@@ -24,7 +24,7 @@ import models._
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/services/DisposeLiabilityReturnServiceSpec.scala
+++ b/test/services/DisposeLiabilityReturnServiceSpec.scala
@@ -23,7 +23,7 @@ import models._
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/services/FormBundleReturnsServiceSpec.scala
+++ b/test/services/FormBundleReturnsServiceSpec.scala
@@ -24,7 +24,7 @@ import org.joda.time.LocalDate
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/services/PropertyDetailsServiceSpec_Periods.scala
+++ b/test/services/PropertyDetailsServiceSpec_Periods.scala
@@ -23,7 +23,7 @@ import org.joda.time.LocalDate
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/services/PropertyDetailsServiceSpec_Values.scala
+++ b/test/services/PropertyDetailsServiceSpec_Values.scala
@@ -22,7 +22,7 @@ import models._
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json}

--- a/test/services/ReliefsServiceSpec.scala
+++ b/test/services/ReliefsServiceSpec.scala
@@ -25,7 +25,7 @@ import org.joda.time.LocalDate
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.{ArgumentCaptor, ArgumentMatchers}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.PrivateMethodTester
 import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.{JsValue, Json}

--- a/test/services/SubscriptionDataAdapterServiceSpec.scala
+++ b/test/services/SubscriptionDataAdapterServiceSpec.scala
@@ -22,7 +22,7 @@ import connectors.AtedConnector
 import models._
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.{JsValue, Json}
 import play.api.test.Helpers._

--- a/test/services/SubscriptionDataServiceSpec.scala
+++ b/test/services/SubscriptionDataServiceSpec.scala
@@ -24,7 +24,7 @@ import models._
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.logging.SessionId

--- a/test/testhelpers/AtedViewSpec.scala
+++ b/test/testhelpers/AtedViewSpec.scala
@@ -18,7 +18,7 @@ package testhelpers
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/testhelpers/MockAuthUtil.scala
+++ b/test/testhelpers/MockAuthUtil.scala
@@ -22,7 +22,7 @@ import models.{DelegationModel, StandardAuthRetrievals}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.when
 import org.mockito.stubbing.OngoingStubbing
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import services.DelegationService
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.auth.core._

--- a/test/utils/CountryCodeUtilsSpec.scala
+++ b/test/utils/CountryCodeUtilsSpec.scala
@@ -16,7 +16,7 @@
 
 package utils
 
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Environment

--- a/test/utils/FeatureSwitchSpec.scala
+++ b/test/utils/FeatureSwitchSpec.scala
@@ -18,7 +18,7 @@ package utils
 
 import config.ApplicationConfig
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 

--- a/test/views/editLiability/bankDetailsSpec.scala
+++ b/test/views/editLiability/bankDetailsSpec.scala
@@ -21,7 +21,7 @@ import forms.BankDetailForms._
 import testhelpers.MockAuthUtil
 import models.StandardAuthRetrievals
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/editLiability/disposeLiabilityBankDetailsSpec.scala
+++ b/test/views/editLiability/disposeLiabilityBankDetailsSpec.scala
@@ -21,7 +21,7 @@ import forms.BankDetailForms._
 import testhelpers.MockAuthUtil
 import models.StandardAuthRetrievals
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/editLiability/disposeLiabilityHasBankDetailsSpec.scala
+++ b/test/views/editLiability/disposeLiabilityHasBankDetailsSpec.scala
@@ -21,7 +21,7 @@ import forms.BankDetailForms._
 import testhelpers.MockAuthUtil
 import models.StandardAuthRetrievals
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/editLiability/editLiabilityDatesLiableSpec.scala
+++ b/test/views/editLiability/editLiabilityDatesLiableSpec.scala
@@ -21,7 +21,7 @@ import forms.PropertyDetailsForms._
 import testhelpers.MockAuthUtil
 import models.StandardAuthRetrievals
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/editLiability/editLiabilitySpec.scala
+++ b/test/views/editLiability/editLiabilitySpec.scala
@@ -21,7 +21,7 @@ import forms.AtedForms._
 import testhelpers.MockAuthUtil
 import models.StandardAuthRetrievals
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/editLiability/editLiabilitySummarySpec.scala
+++ b/test/views/editLiability/editLiabilitySummarySpec.scala
@@ -23,7 +23,7 @@ import models.StandardAuthRetrievals
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{DateTimeZone, LocalDate}
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/editLiability/editLiabilityValueSpec.scala
+++ b/test/views/editLiability/editLiabilityValueSpec.scala
@@ -21,7 +21,7 @@ import forms.PropertyDetailsForms._
 import testhelpers.MockAuthUtil
 import models.{HasValueChanged, StandardAuthRetrievals}
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/editLiability/hasBankDetailsSpec.scala
+++ b/test/views/editLiability/hasBankDetailsSpec.scala
@@ -21,7 +21,7 @@ import forms.BankDetailForms._
 import testhelpers.MockAuthUtil
 import models.StandardAuthRetrievals
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/formBundleReturnSpec.scala
+++ b/test/views/formBundleReturnSpec.scala
@@ -22,7 +22,7 @@ import testhelpers.MockAuthUtil
 import models._
 import org.joda.time.LocalDate
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/html/ReturnTypeSpec.scala
+++ b/test/views/html/ReturnTypeSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import forms.AtedForms
 import testhelpers.{AtedViewSpec, MockAuthUtil}
 import models.StandardAuthRetrievals
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages
 import play.twirl.api.Html
 

--- a/test/views/html/editLiability/BankDetailsSpec.scala
+++ b/test/views/html/editLiability/BankDetailsSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import forms.BankDetailForms
 import testhelpers.{AtedViewSpec, MockAuthUtil}
 import models.StandardAuthRetrievals
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.data.{Form, FormError}
 import play.twirl.api.Html
 

--- a/test/views/html/editLiability/EditLiabilityDatesLiableSpec.scala
+++ b/test/views/html/editLiability/EditLiabilityDatesLiableSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import forms.PropertyDetailsForms
 import testhelpers.{AtedViewSpec, MockAuthUtil}
 import models.StandardAuthRetrievals
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.data.{Form, FormError}
 import play.api.i18n.Messages
 import play.twirl.api.Html

--- a/test/views/html/propertyDetails/IsFullTaxPeriodSpec.scala
+++ b/test/views/html/propertyDetails/IsFullTaxPeriodSpec.scala
@@ -21,7 +21,7 @@ import forms.PropertyDetailsForms
 import testhelpers.{AtedViewSpec, MockAuthUtil}
 import models.StandardAuthRetrievals
 import org.joda.time.LocalDate
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages
 import play.twirl.api.Html
 

--- a/test/views/html/propertyDetails/PropertyDetailsAcquisitionSpec.scala
+++ b/test/views/html/propertyDetails/PropertyDetailsAcquisitionSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import forms.PropertyDetailsForms
 import testhelpers.{AtedViewSpec, MockAuthUtil}
 import models.StandardAuthRetrievals
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages
 import play.twirl.api.Html
 import uk.gov.hmrc.auth.core.{AffinityGroup, Enrolments}

--- a/test/views/html/propertyDetails/PropertyDetailsInReliefSpec.scala
+++ b/test/views/html/propertyDetails/PropertyDetailsInReliefSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import forms.PropertyDetailsForms
 import testhelpers.{AtedViewSpec, MockAuthUtil}
 import models.StandardAuthRetrievals
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages
 import play.twirl.api.Html
 

--- a/test/views/html/propertyDetails/PropertyDetailsNewBuildSpec.scala
+++ b/test/views/html/propertyDetails/PropertyDetailsNewBuildSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import forms.PropertyDetailsForms
 import testhelpers.{AtedViewSpec, MockAuthUtil}
 import models.StandardAuthRetrievals
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.data.{Form, FormError}
 import play.api.i18n.Messages
 import play.twirl.api.Html

--- a/test/views/html/propertyDetails/PropertyDetailsOwnedBeforeSpec.scala
+++ b/test/views/html/propertyDetails/PropertyDetailsOwnedBeforeSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import forms.PropertyDetailsForms
 import testhelpers.{AtedViewSpec, MockAuthUtil}
 import models.StandardAuthRetrievals
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.data.{Form, FormError}
 import play.api.i18n.Messages
 import play.twirl.api.Html

--- a/test/views/html/propertyDetails/PropertyDetailsProfessionallyValuedSpec.scala
+++ b/test/views/html/propertyDetails/PropertyDetailsProfessionallyValuedSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import forms.PropertyDetailsForms
 import testhelpers.{AtedViewSpec, MockAuthUtil}
 import models.StandardAuthRetrievals
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages
 import play.twirl.api.Html
 

--- a/test/views/html/propertyDetails/PropertyDetailsRevaluedHtmlViewSpec.scala
+++ b/test/views/html/propertyDetails/PropertyDetailsRevaluedHtmlViewSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import forms.PropertyDetailsForms
 import testhelpers.{AtedViewSpec, MockAuthUtil}
 import models.StandardAuthRetrievals
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages
 import play.twirl.api.Html
 

--- a/test/views/html/propertyDetails/PropertyDetailsTaxAvoidanceHtmlViewSpec.scala
+++ b/test/views/html/propertyDetails/PropertyDetailsTaxAvoidanceHtmlViewSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import forms.PropertyDetailsForms
 import testhelpers.{AtedViewSpec, MockAuthUtil}
 import models.StandardAuthRetrievals
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.data.{Form, FormError}
 import play.api.i18n.Messages
 import play.twirl.api.Html

--- a/test/views/html/reliefs/ChooseReliefsSpec.scala
+++ b/test/views/html/reliefs/ChooseReliefsSpec.scala
@@ -21,7 +21,7 @@ import forms.ReliefForms
 import testhelpers.{AtedViewSpec, MockAuthUtil}
 import models.{Reliefs, StandardAuthRetrievals}
 import org.joda.time.LocalDate
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.data.Form
 import play.api.i18n.Messages
 import play.api.libs.json.Json

--- a/test/views/html/reliefs/IsAvoidanceSchemeSpec.scala
+++ b/test/views/html/reliefs/IsAvoidanceSchemeSpec.scala
@@ -21,7 +21,7 @@ import forms.ReliefForms
 import testhelpers.{AtedViewSpec, MockAuthUtil}
 import models.{IsTaxAvoidance, StandardAuthRetrievals}
 import org.joda.time.LocalDate
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.data.Form
 import play.api.i18n.Messages
 import play.api.libs.json.Json

--- a/test/views/html/reliefs/ReliefDeclarationSpec.scala
+++ b/test/views/html/reliefs/ReliefDeclarationSpec.scala
@@ -19,7 +19,7 @@ package views.html.reliefs
 import config.ApplicationConfig
 import testhelpers.{AtedViewSpec, MockAuthUtil}
 import models.StandardAuthRetrievals
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages
 import play.twirl.api.Html
 

--- a/test/views/html/subscriptionData/CompanyDetailsSpec.scala
+++ b/test/views/html/subscriptionData/CompanyDetailsSpec.scala
@@ -19,7 +19,7 @@ package views.html.subscriptionData
 import config.ApplicationConfig
 import testhelpers.{AtedViewSpec, MockAuthUtil}
 import models._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.twirl.api.Html
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.auth.core.{AffinityGroup, Enrolments}

--- a/test/views/html/subscriptionData/EditContactDetailsSpec.scala
+++ b/test/views/html/subscriptionData/EditContactDetailsSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import forms.AtedForms.editContactDetailsForm
 import testhelpers.{AtedViewSpec, MockAuthUtil}
 import models._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages
 import play.twirl.api.Html
 

--- a/test/views/html/subscriptionData/EditContactEmailSpec.scala
+++ b/test/views/html/subscriptionData/EditContactEmailSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import forms.AtedForms.editContactDetailsEmailForm
 import testhelpers.{AtedViewSpec, MockAuthUtil}
 import models._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages
 import play.twirl.api.Html
 

--- a/test/views/periodSummaryPastReturnsSpec.scala
+++ b/test/views/periodSummaryPastReturnsSpec.scala
@@ -21,7 +21,7 @@ import testhelpers.MockAuthUtil
 import models._
 import org.joda.time.LocalDate
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/periodSummarySpec.scala
+++ b/test/views/periodSummarySpec.scala
@@ -21,7 +21,7 @@ import testhelpers.MockAuthUtil
 import models._
 import org.joda.time.LocalDate
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/propertyDetails/PropertyDetailsAddressSpec.scala
+++ b/test/views/propertyDetails/PropertyDetailsAddressSpec.scala
@@ -22,7 +22,7 @@ import forms.PropertyDetailsForms._
 import testhelpers.MockAuthUtil
 import models.StandardAuthRetrievals
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/propertyDetails/PropertyDetailsRevaluedViewSpec.scala
+++ b/test/views/propertyDetails/PropertyDetailsRevaluedViewSpec.scala
@@ -22,7 +22,7 @@ import testhelpers.MockAuthUtil
 import models.{PropertyDetailsRevalued, StandardAuthRetrievals}
 import org.joda.time.LocalDate
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/propertyDetails/addressLookupResultsSpec.scala
+++ b/test/views/propertyDetails/addressLookupResultsSpec.scala
@@ -21,7 +21,7 @@ import forms.AddressLookupForms._
 import testhelpers.MockAuthUtil
 import models._
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/propertyDetails/addressLookupSpec.scala
+++ b/test/views/propertyDetails/addressLookupSpec.scala
@@ -21,7 +21,7 @@ import forms.AddressLookupForms._
 import testhelpers.MockAuthUtil
 import models.StandardAuthRetrievals
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/propertyDetails/confirmAddressSpec.scala
+++ b/test/views/propertyDetails/confirmAddressSpec.scala
@@ -18,7 +18,7 @@ package views.propertyDetails
 
 import config.ApplicationConfig
 import models.{PropertyDetailsAddress, StandardAuthRetrievals}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}
 import play.api.test.FakeRequest
@@ -30,7 +30,7 @@ import models.StandardAuthRetrievals
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{DateTimeZone, LocalDate}
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/propertyDetails/periodChooseReliefSpec.scala
+++ b/test/views/propertyDetails/periodChooseReliefSpec.scala
@@ -22,7 +22,7 @@ import testhelpers.MockAuthUtil
 import models.{PeriodChooseRelief, StandardAuthRetrievals}
 import org.joda.time.LocalDate
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/propertyDetails/periodDatesLiableSpec.scala
+++ b/test/views/propertyDetails/periodDatesLiableSpec.scala
@@ -21,7 +21,7 @@ import forms.PropertyDetailsForms._
 import testhelpers.MockAuthUtil
 import models.StandardAuthRetrievals
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/propertyDetails/periodInReliefDatesSpec.scala
+++ b/test/views/propertyDetails/periodInReliefDatesSpec.scala
@@ -21,7 +21,7 @@ import forms.PropertyDetailsForms._
 import testhelpers.MockAuthUtil
 import models.StandardAuthRetrievals
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/propertyDetails/periodsInAndOutReliefSpec.scala
+++ b/test/views/propertyDetails/periodsInAndOutReliefSpec.scala
@@ -22,7 +22,7 @@ import testhelpers.MockAuthUtil
 import models.{LineItem, StandardAuthRetrievals}
 import org.joda.time.LocalDate
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/propertyDetails/propertyDetailsPrintFriendlySpec.scala
+++ b/test/views/propertyDetails/propertyDetailsPrintFriendlySpec.scala
@@ -23,7 +23,7 @@ import models.StandardAuthRetrievals
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{DateTimeZone, LocalDate}
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/propertyDetails/propertyDetailsSummarySpec.scala
+++ b/test/views/propertyDetails/propertyDetailsSummarySpec.scala
@@ -23,7 +23,7 @@ import models.StandardAuthRetrievals
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{DateTimeZone, LocalDate}
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/propertyDetails/propertyDetailsTitleSpec.scala
+++ b/test/views/propertyDetails/propertyDetailsTitleSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import forms.PropertyDetailsForms._
 import testhelpers.MockAuthUtil
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/reliefs/ReliefDeclarationSpec.scala
+++ b/test/views/reliefs/ReliefDeclarationSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import testhelpers.MockAuthUtil
 import models.StandardAuthRetrievals
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/reliefs/ReliefsSentPrintFriendlySpec.scala
+++ b/test/views/reliefs/ReliefsSentPrintFriendlySpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import models.{ReliefReturnResponse, StandardAuthRetrievals, SubmitReturnsResponse}
 import org.joda.time.LocalDate
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/reliefs/ReliefsSentSpec.scala
+++ b/test/views/reliefs/ReliefsSentSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import models.{ReliefReturnResponse, StandardAuthRetrievals, SubmitReturnsResponse}
 import org.joda.time.LocalDate
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/reliefs/ReliefsSummarySpec.scala
+++ b/test/views/reliefs/ReliefsSummarySpec.scala
@@ -19,7 +19,7 @@ package views.reliefs
 import config.ApplicationConfig
 import testhelpers.MockAuthUtil
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/reliefs/changeReliefReturnSpec.scala
+++ b/test/views/reliefs/changeReliefReturnSpec.scala
@@ -19,7 +19,7 @@ package views.reliefs
 import config.ApplicationConfig
 import forms.AtedForms.editReliefForm
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/reliefs/chooseReliefsSpec.scala
+++ b/test/views/reliefs/chooseReliefsSpec.scala
@@ -22,7 +22,7 @@ import testhelpers.MockAuthUtil
 import models.{Reliefs, StandardAuthRetrievals}
 import org.joda.time.LocalDate
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/reliefs/isAvoidanceSchemeSpec.scala
+++ b/test/views/reliefs/isAvoidanceSchemeSpec.scala
@@ -22,7 +22,7 @@ import testhelpers.MockAuthUtil
 import models.{IsTaxAvoidance, StandardAuthRetrievals}
 import org.joda.time.LocalDate
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/views/selectPeriodSpec.scala
+++ b/test/views/selectPeriodSpec.scala
@@ -22,7 +22,7 @@ import testhelpers.MockAuthUtil
 import models.StandardAuthRetrievals
 import org.joda.time.LocalDate
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.i18n.{Messages, MessagesApi}


### PR DESCRIPTION
**Bug fix**

There has been a long-standing issue in ATED where users are being taken to the summary page which tries to do a calculation but the user has not yet provided all of the information required for this calculation to happen in ETMP so a 400 is returned from ETMP and an exception is thrown causing the user to see an error.

This fix is to recognise the error has happened and instead of throwing an exception, take the user to the summary which doesn't perform a calculation so the user has the opportunity to complete any missing information from earlier in the flow (they will see INCOMPLETE next to those sections).

## Checklist

*Reviewee* (David Thornton)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [x]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date