### PR TITLE
DL-2384: Added css files to correct colour contrasts for WCAG 2.1

### DIFF
--- a/app/views/atedMain.scala.html
+++ b/app/views/atedMain.scala.html
@@ -46,8 +46,8 @@
     </script>
 
 @linkElement = {
-    <link rel="stylesheet" type="text/css" href='@controllers.routes.Assets.versioned("stylesheets/palette.css")'>
-    <link rel="stylesheet" type="text/css" href='@controllers.routes.Assets.versioned("stylesheets/focus.css")'>
+    <link rel="stylesheet" href='@controllers.routes.Assets.versioned("stylesheets/palette.css")'/>
+    <link rel="stylesheet" href='@controllers.routes.Assets.versioned("stylesheets/focus.css")'/>
     <link rel="stylesheet" href='@controllers.routes.Assets.versioned("stylesheets/main.css")'/>
     <link rel="stylesheet" href='@controllers.routes.Assets.versioned("stylesheets/urBanner.css")'/>
     <link rel="stylesheet" href='@controllers.routes.Assets.versioned("stylesheets/_checkAnswers.css")'/>

--- a/app/views/atedMain.scala.html
+++ b/app/views/atedMain.scala.html
@@ -46,6 +46,8 @@
     </script>
 
 @linkElement = {
+    <link rel="stylesheet" type="text/css" href='@controllers.routes.Assets.versioned("stylesheets/palette.css")'>
+    <link rel="stylesheet" type="text/css" href='@controllers.routes.Assets.versioned("stylesheets/focus.css")'>
     <link rel="stylesheet" href='@controllers.routes.Assets.versioned("stylesheets/main.css")'/>
     <link rel="stylesheet" href='@controllers.routes.Assets.versioned("stylesheets/urBanner.css")'/>
     <link rel="stylesheet" href='@controllers.routes.Assets.versioned("stylesheets/_checkAnswers.css")'/>

--- a/app/views/atedNoAuthMain.scala.html
+++ b/app/views/atedNoAuthMain.scala.html
@@ -24,7 +24,9 @@
 
 
 @linkElement = {
-<link rel="stylesheet" href='@controllers.routes.Assets.versioned("stylesheets/main.css?v0.2")'/>
+    <link rel="stylesheet" href='@controllers.routes.Assets.versioned("stylesheets/palette.css")'/>
+    <link rel="stylesheet" href='@controllers.routes.Assets.versioned("stylesheets/focus.css")'/>
+    <link rel="stylesheet" href='@controllers.routes.Assets.versioned("stylesheets/main.css?v0.2")'/>
 }
 
 @main(

--- a/app/views/error/individual.scala.html
+++ b/app/views/error/individual.scala.html
@@ -46,6 +46,6 @@
 <p>@messages("unauthorised.nonUK.p4")</p>
 
 
-<a href="/ated/sign-out-individual">
- <button class="button">@messages("unauthorised.button.signout")</button>
+<a class="button" role="button" href="/ated/sign-out-individual">
+ @messages("unauthorised.button.signout")
 </a>

--- a/app/views/propertyDetails/confirmAddress.scala.html
+++ b/app/views/propertyDetails/confirmAddress.scala.html
@@ -41,16 +41,22 @@
     </div>
 
     <div class="margin-top-default">
-        <a href="@controllers.propertyDetails.routes.PropertyDetailsAddressController.view(id, fromConfirmAddressPage = true, periodKey, mode)"
-        id="edit-address-link"
-        data-journey-click="ated-fronted:click:manual-entry"
-        onkeyup='spaceBarHandler(event, "@controllers.propertyDetails.routes.PropertyDetailsAddressController.view(id, fromConfirmAddressPage = true, periodKey, mode)")'>
-            <p id="editAddress">@Messages("ated.confirm-address.editAddress")</p>
-        </a>
 
-        <a href="@controllers.routes.ExistingReturnQuestionController.view(periodKey, "charge")">
-            <p id="selectADifferentProperty">@Messages("ated.confirm-address.selectDifferentProperty")</p>
-        </a>
+            <p id="editAddress">
+                <a href="@controllers.propertyDetails.routes.PropertyDetailsAddressController.view(id, fromConfirmAddressPage = true, periodKey, mode)"
+                id="edit-address-link"
+                data-journey-click="ated-fronted:click:manual-entry"
+                onkeyup='spaceBarHandler(
+                    event, "@controllers.propertyDetails.routes.PropertyDetailsAddressController.view(id, fromConfirmAddressPage = true, periodKey, mode)")'>
+                    @Messages("ated.confirm-address.editAddress")
+                </a>
+            </p>
+
+            <p id="selectADifferentProperty">
+                <a href="@controllers.routes.ExistingReturnQuestionController.view(periodKey, "charge")">
+                    @Messages("ated.confirm-address.selectDifferentProperty")
+                </a>
+            </p>
 
         @form(action = controllers.propertyDetails.routes.ConfirmAddressController.submit(id, periodKey, mode)) {
             <p>

--- a/app/views/propertyDetails/periodsInAndOutRelief.scala.html
+++ b/app/views/propertyDetails/periodsInAndOutRelief.scala.html
@@ -36,13 +36,13 @@
   ga('set', 'page', page);
 }
 
-@atedMain(title = messages("ated.property-details-period.peroidsInRelief.title"),
+@atedMain(title = messages("ated.property-details-period.periodsInRelief.title"),
           analyticsAdditionalJs = Some(analyticsJs)) {
           @pageHeadersAndError(backLink,
             "pre-heading",
             messages(AtedUtils.getPropertyDetailsPreHeader(mode)),
             "property-details-header",
-            messages("ated.property-details-period.peroidsInRelief.header"),
+            messages("ated.property-details-period.periodsInRelief.header"),
             Some(atedErrorSummary(propertyDetailsForm, "ated.property-details-period-error.general")
           ))
 
@@ -75,12 +75,12 @@
 
   <div class="margin-bottom-default">
     <a href="@controllers.propertyDetails.routes.PeriodDatesLiableController.add(id, periodKey)"
-       id="add-period-charge" class="button button--secondary btn-margin">
+       id="add-period-charge" class="button--secondary btn-margin">
       @messages("ated.property-details-period.periodsInRelief.add-charge")
     </a>
 
     <a href="@controllers.propertyDetails.routes.PeriodChooseReliefController.add(id, periodKey)"
-       id="add-period-in-relief" class="button button--secondary btn-margin">
+       id="add-period-in-relief" class="button--secondary btn-margin">
       @messages("ated.property-details-period.periodsInRelief.add-relief")
     </a>
   </div>

--- a/conf/messages
+++ b/conf/messages
@@ -757,8 +757,8 @@ ated.property-details-period.datesInRelief.endDate.error.too-late = The end date
 ated.property-details-period.datesInRelief.endDate.error.before-start-date = The relief end date cannot be before the relief start date
 ated.property-details-period.datesInRelief.endDate.error.before-start-date-and-too-early = The relief end date cannot be before the liability start date and must be within this chargeable period
 
-ated.property-details-period.peroidsInRelief.title = Add periods when the property was in relief and when it was liable for an ATED charge
-ated.property-details-period.peroidsInRelief.header = Add periods when the property was in relief and when it was liable for an ATED charge
+ated.property-details-period.periodsInRelief.title = Add periods when the property was in relief and when it was liable for an ATED charge
+ated.property-details-period.periodsInRelief.header = Add periods when the property was in relief and when it was liable for an ATED charge
 ated.property-details-period.periodsInRelief.no-periods = No periods of relief or charge have been added yet
 ated.property-details-period.periodsInRelief.date-from-header = Date from
 ated.property-details-period.periodsInRelief.date-to-header = Date to

--- a/public/stylesheets/focus.css
+++ b/public/stylesheets/focus.css
@@ -1,0 +1,91 @@
+a:focus,
+.error-summary .error-summary-list a:focus,
+details summary:focus {
+    outline: 3px solid transparent;
+    color: #0b0c0c;
+    background-color: #fd0;
+    -webkit-box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+    box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+    text-decoration: none;
+}
+
+details summary:focus .summary {
+    text-decoration: none;
+}
+
+input:focus,
+textarea:focus,
+select:focus,
+#global-header input:focus {
+    outline-color: #fd0;
+}
+
+.button {
+    border: 2px solid transparent;
+}
+
+.button:focus:not(:active):not(:hover) {
+    border-color: #fd0;
+    color: #0b0c0c;
+    background-color: #fd0;
+    -webkit-box-shadow: 0 2px 0 #0b0c0c;
+    box-shadow: 0 2px 0 #0b0c0c;
+    outline: 3px solid transparent;
+}
+
+.button:focus {
+    border-color: #fd0;
+    outline: 3px solid transparent;
+    -webkit-box-shadow: inset 0 0 0 1px #fd0;
+    box-shadow: inset 0 0 0 1px #fd0;
+}
+
+.form-control:focus {
+    outline: 3px solid #fd0;
+    outline-offset: 0;
+    -webkit-box-shadow: inset 0 0 0 2px;
+    box-shadow: inset 0 0 0 2px;
+}
+
+.multiple-choice [type=checkbox]:focus+label::before {
+    border-width: 3px;
+}
+
+.report-error .report-error__toggle:focus,
+#footer a:focus,
+#global-header .header-proposition #proposition-links li a:focus,
+#global-header .header-proposition a.menu:focus,
+#global-header #logo:focus {
+    color: #0b0c0c;
+}
+
+#global-header #logo:focus img {
+    filter: invert(1);
+}
+
+.account-menu__link:focus,
+.is-smaller .account-menu__link--home:focus,
+.is-smaller .account-menu__link--menu:focus,
+.is-smaller .account-menu__link--home.account-menu__link--active:focus,
+.is-smaller .account-menu__link--menu.account-menu__link--active:focus {
+    color: #0b0c0c;
+    background-color: #fd0;
+}
+
+@media (min-width: 641px){
+    #footer .footer-meta .copyright a {
+        background-position: 50% 0;
+        float: right;
+    }
+}
+
+#footer .footer-meta .copyright a:focus {
+    background-color: #fd0;
+}
+
+textarea:focus {
+    outline: 3px solid #fd0;
+    outline-offset: 0;
+    -webkit-box-shadow: inset 0 0 0 2px;
+    box-shadow: inset 0 0 0 2px;
+}

--- a/public/stylesheets/focus.css
+++ b/public/stylesheets/focus.css
@@ -20,11 +20,11 @@ select:focus,
     outline-color: #fd0;
 }
 
-.button {
+.button, .button--secondary {
     border: 2px solid transparent;
 }
 
-.button:focus:not(:active):not(:hover) {
+.button:focus, .button--secondary:focus:not(:active):not(:hover) {
     border-color: #fd0;
     color: #0b0c0c;
     background-color: #fd0;
@@ -33,7 +33,7 @@ select:focus,
     outline: 3px solid transparent;
 }
 
-.button:focus {
+.button:focus, .button--secondary:focus {
     border-color: #fd0;
     outline: 3px solid transparent;
     -webkit-box-shadow: inset 0 0 0 1px #fd0;

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -1,3 +1,7 @@
+a.banner-links {
+    color: #0B0B0B;
+}
+
 button {
     margin: 20px 0px 30px 0px;
 }

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -1,5 +1,5 @@
 a.banner-links {
-    color: #0B0B0B;
+    color: #0b0b0b;
 }
 
 button {

--- a/public/stylesheets/palette.css
+++ b/public/stylesheets/palette.css
@@ -1,0 +1,275 @@
+.button--secondary,
+.button--secondary:visited,
+.button--secondary.disabled:hover,
+.button--secondary[disabled="disabled"]:hover,
+.button--secondary[disabled]:hover,
+.block-label,
+.block-label--stacked,
+.footer,
+.box--shaded,
+.side-nav__link:hover,
+.dataTable tbody .status--unconfirmed,
+.tag,
+.tabs-nav .tabs-nav__tab:focus,
+.tabs-nav .tabs-nav__tab:hover,
+.tabs-nav .tabs-nav__tab:active,
+.tabs-nav a.tabs-nav__tab:focus,
+.tabs-nav .tabs-nav__tab.link-style:focus,
+.tabs-nav .tabs-nav__tab.button--link-style:focus,
+.tabs-nav a.tabs-nav__tab:hover,
+.tabs-nav .tabs-nav__tab.link-style:hover,
+.tabs-nav .tabs-nav__tab.button--link-style:hover,
+.tabs-nav a.tabs-nav__tab:active,
+.tabs-nav .tabs-nav__tab.link-style:active,
+.tabs-nav .tabs-nav__tab.button--link-style:active,
+.annual-summaries--group .statement__summary--parent[aria-expanded=true],
+.payments .table-label.selected,
+.payments .table-label:hover,
+html {
+    background-color: #f3f2f1;
+}
+
+.button--secondary:active {
+    -webkit-box-shadow: 0 0 0 #f3f2f1;
+    box-shadow: 0 0 0 #f3f2f1
+}
+
+.block-label,
+.block-label--stacked {
+    border-color: #f3f2f1;
+}
+
+.dynamically-displayed {
+    border-left: 5px solid #f3f2f1;
+}
+
+.explore a,
+.explore--inside-government a,
+.explore--inline a,
+.explore .link-style,
+.explore--inside-government .link-style,
+.explore--inline .link-style,
+.explore .button--link-style,
+.explore--inside-government .button--link-style,
+.explore--inline .button--link-style,
+.explore--inline__links {
+    color: #f3f2f1;
+}
+
+.indent {
+    border-left-color: #f3f2f1;
+}
+
+.services-dashboard .service-option--links:first-child .service-option--item,
+.account-menu__link:hover,
+.is-smaller .account-menu__link--back {
+    border-bottom-color: #f3f2f1;
+}
+
+.heading--underlined,
+.section--branded h2,
+.table--light-header thead,
+.table__header--highlight,
+.business-tax .section--branded h2,
+.is-smaller .account-menu__link--home.account-menu__link--active:hover,
+.account-menu__link--active,
+.account-menu__link--active:visited {
+    border-bottom-color: #1d70b8;
+}
+
+.heading-large--blue,
+.button.button--link,
+a.back-to-top-link:visited,
+.back-to-top-link.link-style:visited,
+.back-to-top-link.button--link-style:visited,
+.page-nav__link,
+.banner-links,
+.side-nav--child .side-nav__list--selected .side-nav__link,
+.dataTables_paginate a,
+.dataTables_paginate .link-style,
+.dataTables_paginate .button--link-style,
+.accordion__button:visited,
+.toggle__button,
+.tabs-nav .tabs-nav__tab:visited,
+.tabs-nav__tab,
+.payments .tab,
+.services-dashboard .service-option--links .service-option--link:link,
+.link,
+.link:active,
+details summary,
+a,
+.link-style,
+.button--link-style,
+.button--link-style,
+.subnav a:visited,
+.subnav .link-style:visited,
+.subnav .button--link-style:visited,
+.is-smaller .subnav__section a:hover,
+.is-smaller .subnav__section .link-style:hover,
+.is-smaller .subnav__section .button--link-style:hover {
+    color: #1d70b8
+}
+
+.brand-border--top,
+.section--blue-top,
+.footer,
+.service-info {
+    border-top-color: #1d70b8;
+}
+
+.button--notification,
+.button--notification:visited,
+.button--notification.disabled:hover,
+.button--notification[disabled="disabled"]:hover,
+.button--notification[disabled]:hover,
+.alpha-banner .phase-tag,
+.beta-banner .phase-tag,
+.phase-tag,
+.side-nav__list--selected .side-nav__link,
+.side-nav__list--selected:hover .side-nav__link,
+.highlight-message--dark,
+.hero,
+.paye-statements .sidebar-links__item.selected,
+option:active,
+option:checked,
+select:focus::-ms-value,
+.phase-banner .phase-tag,
+.phase-banner-alpha .phase-tag,
+.phase-banner-beta .phase-tag,
+.phase-tag,
+.full-width-banner,
+.hmrc-banner .phase-tag {
+    background-color: #1d70b8;
+}
+
+.button--notification:active {
+    -webkit-box-shadow: 0 0 0 #1d70b8;
+    box-shadow: 0 0 0 #1d70b8;
+}
+
+.attorneyBanner,
+.panel-indent--info,
+.delegation-banner {
+    border-left-color: #1d70b8;
+}
+
+.page-nav__link:focus,
+.js-enabled .add-focus,
+.modal-dialog__content:focus,
+.button:focus,
+details summary:focus,
+.error-summary:focus {
+    outline-color: #ffdd00;
+}
+
+.multiple-choice [type=radio]:focus+label::before {
+    -webkit-box-shadow: 0 0 0 4px #ffdd00;
+    box-shadow: 0 0 0 4px #ffdd00;
+}
+
+.multiple-choice [type=checkbox]:focus+label::before {
+    -webkit-box-shadow: 0 0 0 3px #ffdd00;
+    box-shadow: 0 0 0 3px #ffdd00
+}
+
+.account-menu__link:focus,
+.is-smaller .account-menu__link--home:focus,
+.is-smaller .account-menu__link--menu:focus,
+.is-smaller .account-menu__link--home.account-menu__link--active:focus,
+.is-smaller .account-menu__link--menu.account-menu__link--active:focus {
+    border-bottom-color: #ffdd00;
+}
+
+button,
+.button,
+button:visited,
+.button:visited,
+button.disabled:hover,
+button[disabled="disabled"]:hover,
+button[disabled]:hover,
+.button.disabled:hover,
+.button[disabled="disabled"]:hover,
+.button[disabled]:hover,
+.button--small,
+.button--small:visited,
+.button--small.disabled:hover,
+.button--small[disabled="disabled"]:hover,
+.button--small[disabled]:hover,
+.toggle__button--active,
+.toggle__button--active:hover,
+.toggle__button--active:focus,
+.button[disabled="disabled"] {
+    background-color: #00703c;
+}
+
+button:active,
+.button:active,
+.button--small:active {
+    -webkit-box-shadow: 0 0 0 #00703c;
+    box-shadow: 0 0 0 #00703c;
+}
+
+.list--ticks li::before,
+.tick,
+.form-hint-list-item--valid {
+    color: #00703c;
+}
+
+.button--alert,
+.button--alert:visited,
+.button--alert.disabled:hover,
+.button--alert[disabled="disabled"]:hover,
+.button--alert[disabled]:hover,
+.marker-column__marker,
+.reminder.urgent a,
+.reminder.urgent .link-style,
+.reminder.urgent .button--link-style,
+.alert-block,
+.alert--important,
+.tabs-nav .tabs-nav__tab .count,
+.flag.flag--urgent,
+.highlight-block--red,
+.main-nav .count,
+.badge {
+    background-color: #d4351c;
+}
+
+.button--alert:active {
+    -webkit-box-shadow: 0 0 0 #d4351c;
+    box-shadow: 0 0 0 #d4351c;
+}
+
+.email-form-errors .error-notification,
+.annual-summaries--group .alert--text,
+.sent-in-error,
+.business-tax .content__body .flag.flag--urgent,
+.error-message,
+.error-summary .error-summary-list a,
+.error-summary .error-summary-list .link-style,
+.error-summary .error-summary-list .button--link-style {
+    color: #d4351c;
+}
+
+.email-form-errors .error-notification,
+.attorneyBanner--client-request-rejected,
+.business-tax .content__body .flag.flag--urgent,
+.form-group-error {
+    border-left-color: #d4351c;
+}
+
+.business-tax .alert--failure,
+.form-control-error,
+textarea.form-control-error,
+input.form-control-error[type="text"],
+input.form-control-error[type="password"],
+.error-summary {
+    border-color: #d4351c;
+}
+
+.beta-banner .phase-tag {
+    background-color: #1d70b8;
+}
+
+.notice-banner {
+    background-color: #1d70b8;
+}

--- a/public/stylesheets/urBanner.css
+++ b/public/stylesheets/urBanner.css
@@ -11,6 +11,9 @@
 .banner-panel a, .banner-panel a:visited {
     color: #fff;
 }
+.banner-panel a:focus {
+    color: #0b0c0c;
+}
 .banner-panel__close {
     font-size: 14px;
     float: right;


### PR DESCRIPTION
DL-2384: Added css files to correct colour contrasts for WCAG 2.1

Added palette and focus css files as recommended at the time the accessibility statements were being rolled out to address any colour or focus accessibility issues. 

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Paul Anderson)
 - [x]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date