### PR TITLE
DL-3360 Catch NOT FOUND when submitting reliefs

### DIFF
--- a/app/controllers/reliefs/ReliefDeclarationController.scala
+++ b/app/controllers/reliefs/ReliefDeclarationController.scala
@@ -64,6 +64,7 @@ class ReliefDeclarationController @Inject()(mcc: MessagesControllerComponents,
               Future.successful(BadRequest(views.html.global_error("ated.client-problem.title",
                 "ated.client-problem.header", "ated.client-problem.message",
                 Some(appConfig.agentRedirectedToMandate), Some("ated.client-problem.HrefMessage"), None, appConfig)))
+            case NOT_FOUND => Future.successful(Redirect(controllers.reliefs.routes.ReliefsSentController.view(periodKey)))
           }
         }
       }

--- a/app/models/SubmitReturnsResponse.scala
+++ b/app/models/SubmitReturnsResponse.scala
@@ -51,3 +51,12 @@ object SubmitReturnsResponse {
   implicit val jodaDateTimeWrites = Writes.jodaDateWrites(dateFormat)
   implicit val formats = Json.format[SubmitReturnsResponse]
 }
+
+case class AlreadySubmittedReturnsResponse(
+                                  reliefReturnResponse: Option[Seq[ReliefReturnResponse]] = None,
+                                  liabilityReturnResponse: Option[Seq[LiabilityReturnResponse]] = None
+                                )
+
+object AlreadySubmittedReturnsResponse {
+  implicit val formats = Json.format[AlreadySubmittedReturnsResponse]
+}

--- a/app/utils/AtedConstants.scala
+++ b/app/utils/AtedConstants.scala
@@ -23,6 +23,7 @@ object AtedConstants {
   val IdentifierSafeId: String = "safeid"
   val LoggedInUser: String = "loggedInUser"
   val SubmitReturnsResponseFormId: String = "submit-returns-response-Id"
+  val AlreadySubmittedReturnsResponseFormId: String = "already-submitted-returns-response-Id"
   val SubmitEditedLiabilityReturnsResponseFormId: String = "submit-edited-liability-returns-response-Id"
   val RetrieveReturnsResponseId: String = "get-returns-response-Id"
   val PreviousReturnsDetailsList: String = "previous-return-details-list"

--- a/conf/messages
+++ b/conf/messages
@@ -1504,7 +1504,7 @@ yes-no.error.mandatory.draft.delete = The existing return question must be answe
 ated.confirm-past-return-question.title = Did you file a return for this property last year?
 ated.confirm-past-return-question.header = Did you file a return for this property in {0} to {1}?
 ated.confirm-past-return.error = existing return
-ated.confirm-past-return.p1 = Did you file a return for this property in the previous chargeable period - April 1 {0} to March 31 {1}
+ated.confirm-past-return.p1 = Did you file a return for this property in the previous chargeable period - April 1 {0} to March 31 {1}?
 ated.confirm-past-return-question.error.general.yesNo = Select yes if you filed a return for this property last year
 
 ated.select-past-return.title = Select the property from your previous year returns


### PR DESCRIPTION
DL-3360 Catch NOT FOUND when submitting reliefs

**Bug fix**

Code to catch different status responses when submitting a draft relief. This should help fix the bug displayed in DL-2690

## Checklist

*Iyke*
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Paul Anderson)
 - [x]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date