### PR TITLE
DL-3236 Redirect to summary on no content instead of any non-ok status

### DIFF
--- a/app/controllers/propertyDetails/PropertyDetailsSupportingInfoController.scala
+++ b/app/controllers/propertyDetails/PropertyDetailsSupportingInfoController.scala
@@ -80,9 +80,9 @@ class PropertyDetailsSupportingInfoController @Inject()(mcc: MessagesControllerC
               Future.successful(Ok(views.html.propertyDetails.propertyDetailsSupportingInfo(id, propertyDetails.periodKey, filledForm,
                 mode, AtedUtils.getSummaryBackLink(id, None))))
             }
-          }
         }
       }
+    }
   }
 
   def save(id: String, periodKey: Int, mode: Option[String]): Action[AnyContent] = Action.async { implicit request =>
@@ -95,8 +95,8 @@ class PropertyDetailsSupportingInfoController @Inject()(mcc: MessagesControllerC
           propertyDetails => {
             val backLink = Some(controllers.propertyDetails.routes.PropertyDetailsSupportingInfoController.view(id).url)
             for {
-              _ <- propertyDetailsService.validateCalculateDraftPropertyDetails(id)
               cachedData <- dataCacheConnector.fetchAndGetFormData[Boolean](SelectedPreviousReturn)
+              _ <- propertyDetailsService.validateCalculateDraftPropertyDetails(id, AtedUtils.isEditSubmittedMode(mode) && cachedData.isEmpty)
               _ <- propertyDetailsService.saveDraftPropertyDetailsSupportingInfo(id, propertyDetails)
               result <-
               if (AtedUtils.isEditSubmittedMode(mode) && cachedData.isEmpty) {

--- a/app/models/SubmitReturnsResponse.scala
+++ b/app/models/SubmitReturnsResponse.scala
@@ -43,8 +43,6 @@ case class SubmitReturnsResponse(
                                   liabilityReturnResponse: Option[Seq[LiabilityReturnResponse]] = None
                                   )
 
-
-
 object SubmitReturnsResponse {
   val dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ" //DateTime
   implicit val jodaDateTimeReads = Reads.jodaDateReads(dateFormat)

--- a/app/views/propertyDetails/propertyDetailsSummary.scala.html
+++ b/app/views/propertyDetails/propertyDetailsSummary.scala.html
@@ -98,11 +98,17 @@ backLink: Option[String])(implicit authContext: StandardAuthRetrievals, messages
     <div class="grid grid-1-2 cya-answer">
       <div class="status">@messages("ated.label.incomplete")</div>
     </div>
-
-    <div class="grid grid-1-6 cya-change">
-      <a href="@controllers.editLiability.routes.EditLiabilityHasValueChangedController.view(propertyDetails.id)" id="edit-property-value-incomplete" data-journey-click="ated-fronted:click:edit-property-value">@messages("ated.edit") <span class="visuallyhidden">@messages("ated.form-bundle.view.return.value.only")</span>
-      </a>
-    </div>
+    @if(AtedUtils.isEditSubmitted(propertyDetails)) {
+        <div class="grid grid-1-6 cya-change">
+            <a href="@controllers.editLiability.routes.EditLiabilityHasValueChangedController.editFromSummary(propertyDetails.id, Some(true))" id="edit-property-value-incomplete" data-journey-click="ated-fronted:click:edit-property-value">@messages("ated.edit") <span class="visuallyhidden">@messages("ated.form-bundle.view.return.value.only")</span>
+            </a>
+        </div>
+    }else{
+        <div class="grid grid-1-6 cya-change">
+            <a href="@controllers.propertyDetails.routes.PropertyDetailsOwnedBeforeController.editFromSummary(propertyDetails.id)" id="edit-property-value-incomplete" data-journey-click="ated-fronted:click:edit-property-value">@messages("ated.edit") <span class="visuallyhidden">@messages("ated.form-bundle.view.return.value.only")</span>
+            </a>
+        </div>
+    }
   </div>
 
   } else {
@@ -116,20 +122,20 @@ backLink: Option[String])(implicit authContext: StandardAuthRetrievals, messages
       <span id="property-value-value-@index">@formattedPounds(valueObj.propertyValue)</span>
     </div>
     @if(AtedUtils.isEditSubmitted(propertyDetails)) {
-    <div class="grid grid-1-6 cya-change">
-      <a href="@controllers.editLiability.routes.EditLiabilityHasValueChangedController.editFromSummary(propertyDetails.id, Some(true))" id="edit-property-professionally-value-0">
-        @messages("ated.edit") <span class="visuallyhidden">@PeriodUtils.getPeriodValueMessage(index, valuesToDisplay.size)</span>
-      </a>
-    </div>
+        <div class="grid grid-1-6 cya-change">
+          <a href="@controllers.editLiability.routes.EditLiabilityHasValueChangedController.editFromSummary(propertyDetails.id, Some(true))" id="edit-property-professionally-value-0">
+            @messages("ated.edit") <span class="visuallyhidden">@PeriodUtils.getPeriodValueMessage(index, valuesToDisplay.size)</span>
+          </a>
+        </div>
     } else {
-    <div class="grid grid-1-6 cya-change">
-      <a href="@controllers.propertyDetails.routes.PropertyDetailsOwnedBeforeController.editFromSummary(propertyDetails.id)" id="edit-property-professionally-value-1">
-          @messages("ated.edit")
-          <span class="visuallyhidden">
-              @messages(PeriodUtils.getPeriodValueMessage(index, valuesToDisplay.size))
-          </span>
-      </a>
-    </div>
+        <div class="grid grid-1-6 cya-change">
+          <a href="@controllers.propertyDetails.routes.PropertyDetailsOwnedBeforeController.editFromSummary(propertyDetails.id)" id="edit-property-professionally-value-1">
+              @messages("ated.edit")
+              <span class="visuallyhidden">
+                  @messages(PeriodUtils.getPeriodValueMessage(index, valuesToDisplay.size))
+              </span>
+          </a>
+        </div>
     }
   </div>
   }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,9 +6,9 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     ws,
-     "uk.gov.hmrc" %% "bootstrap-play-26" % "1.7.0",
+     "uk.gov.hmrc" %% "bootstrap-play-26" % "1.8.0",
     "uk.gov.hmrc" %% "auth-client" % "3.0.0-play-26",
-    "uk.gov.hmrc" %% "play-ui" % "8.9.0-play-26",
+    "uk.gov.hmrc" %% "play-ui" % "8.10.0-play-26",
     "uk.gov.hmrc" %% "play-partials" % "6.11.0-play-26",
     "uk.gov.hmrc" %% "domain" % "5.9.0-play-26",
     "uk.gov.hmrc" %% "http-caching-client" % "9.0.0-play-26",

--- a/test/builders/PropertyDetailsBuilder.scala
+++ b/test/builders/PropertyDetailsBuilder.scala
@@ -40,12 +40,13 @@ object PropertyDetailsBuilder {
     ))
   }
 
-  def getPropertyDetailsValueRevaluedByAgent(periodKey: Int): Option[PropertyDetailsValue] = {
+  def getPropertyDetailsValueRevaluedByAgent(periodKey: Int, valueChanged: Option[Boolean] = Some(true)): Option[PropertyDetailsValue] = {
     Some(PropertyDetailsValue(anAcquisition = Some(true),
       isPropertyRevalued = Some(true),
       revaluedValue = Some(BigDecimal(1500000)),
       revaluedDate = Some(new LocalDate(s"$periodKey-04-01")),
-      isValuedByAgent =  Some(true)
+      isValuedByAgent =  Some(true),
+      hasValueChanged = valueChanged
     ))
   }
 
@@ -160,7 +161,8 @@ object PropertyDetailsBuilder {
 
   def getPropertyDetailsValuedByAgent(id: String,
                          postCode: Option[String] = None,
-                         liabilityAmount: Option[BigDecimal] = None)(implicit appConfig: ApplicationConfig): PropertyDetails = {
+                         liabilityAmount: Option[BigDecimal] = None,
+                         valueChanged: Option[Boolean] = Some(true))(implicit appConfig: ApplicationConfig): PropertyDetails = {
     val periodKey: Int = calculatePeakStartYear()
 
     PropertyDetails(
@@ -168,7 +170,7 @@ object PropertyDetailsBuilder {
       periodKey,
       getPropertyDetailsAddress(postCode),
       getPropertyDetailsTitle,
-      getPropertyDetailsValueRevaluedByAgent(periodKey),
+      getPropertyDetailsValueRevaluedByAgent(periodKey, valueChanged),
       getPropertyDetailsPeriod,
       getPropertyDetailsCalculated(liabilityAmount))
   }

--- a/test/controllers/propertyDetails/PropertyDetailsSupportingInfoControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsSupportingInfoControllerSpec.scala
@@ -124,7 +124,7 @@ class PropertyDetailsSupportingInfoControllerSpec extends PlaySpec with GuiceOne
       val userId = s"user-${UUID.randomUUID}"
       when(mockDataCacheConnector.fetchAtedRefData[String](ArgumentMatchers.eq(AtedConstants.DelegatedClientAtedRefNumber))
         (ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some("XN1200000100001")))
-      when(mockPropertyDetailsService.validateCalculateDraftPropertyDetails(ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())).
+      when(mockPropertyDetailsService.validateCalculateDraftPropertyDetails(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())).
         thenReturn(Future.successful(true))
       when(mockPropertyDetailsService.saveDraftPropertyDetailsSupportingInfo(ArgumentMatchers.eq("1"), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())).
         thenReturn(Future.successful(OK))
@@ -144,7 +144,7 @@ class PropertyDetailsSupportingInfoControllerSpec extends PlaySpec with GuiceOne
         (ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some("XN1200000100001")))
       when(mockDataCacheConnector.fetchAndGetFormData[Boolean](ArgumentMatchers.eq(AtedConstants.SelectedPreviousReturn))
         (ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some(true)))
-      when(mockPropertyDetailsService.validateCalculateDraftPropertyDetails(ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())).
+      when(mockPropertyDetailsService.validateCalculateDraftPropertyDetails(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())).
         thenReturn(Future.successful(true))
       when(mockPropertyDetailsService.saveDraftPropertyDetailsSupportingInfo(ArgumentMatchers.eq("1"), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())).
         thenReturn(Future.successful(OK))
@@ -164,7 +164,7 @@ class PropertyDetailsSupportingInfoControllerSpec extends PlaySpec with GuiceOne
         (ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some("XN1200000100001")))
       when(mockDataCacheConnector.fetchAndGetFormData[Boolean](ArgumentMatchers.eq(AtedConstants.SelectedPreviousReturn))
         (ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(None))
-      when(mockPropertyDetailsService.validateCalculateDraftPropertyDetails(ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())).
+      when(mockPropertyDetailsService.validateCalculateDraftPropertyDetails(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())).
         thenReturn(Future.successful(true))
       when(mockPropertyDetailsService.saveDraftPropertyDetailsSupportingInfo(ArgumentMatchers.eq("1"), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())).
         thenReturn(Future.successful(OK))

--- a/test/services/PropertyDetailsServiceSpec.scala
+++ b/test/services/PropertyDetailsServiceSpec.scala
@@ -296,7 +296,7 @@ class PropertyDetailsServiceSpec extends PlaySpec with GuiceOneServerPerSuite wi
         when(mockPropertyDetailsConnector.retrieveDraftPropertyDetails(ArgumentMatchers.eq("1"))(ArgumentMatchers.any(), ArgumentMatchers.any()))
           .thenReturn(Future.successful(HttpResponse(OK, Some(successResponse))))
         when(mockPropertyDetailsConnector.calculateDraftChangeLiability(ArgumentMatchers.any())
-        (ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(HttpResponse(BAD_REQUEST, Some(successResponse))))
+        (ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(HttpResponse(NO_CONTENT, Some(successResponse))))
 
         val result: Future[Option[PropertyDetails]] = testPropertyDetailsService.calculateDraftChangeLiability("1")
         await(result) must be(None)


### PR DESCRIPTION
# DL-3236 Redirect to summary on no content instead of any non-ok status

**Bug fix**

* Changes the way the calculation is handled to only redirect to the summary on a no content with the corrosponding backend change

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date