### PR TITLE
DL-3295 Only send one address block for editing email

### DIFF
--- a/app/services/SubscriptionDataAdapterService.scala
+++ b/app/services/SubscriptionDataAdapterService.scala
@@ -63,10 +63,9 @@ class SubscriptionDataAdapterService @Inject()(atedConnector: AtedConnector) {
     getCorrespondenceAddress(Some(oldData)).map { foundCorrespondence =>
       val editedContactDetail = foundCorrespondence.contactDetails.map(_.copy(emailAddress = Some(editedContactDetails.emailAddress)))
       val updatedAddress = foundCorrespondence.copy(contactDetails = editedContactDetail)
-      val filteredAddresses = oldData.address.filterNot(_.addressDetails.addressType == AtedConstants.AddressTypeCorrespondence)
       val emailConsent = editedContactDetails.emailConsent
-      new UpdateSubscriptionDataRequest(emailConsent = emailConsent, changeIndicators = ChangeIndicators(nameChanged = false,contactDetailsChanged = true),
-        address = filteredAddresses :+ updatedAddress)
+      new UpdateSubscriptionDataRequest(emailConsent = emailConsent, changeIndicators = ChangeIndicators(contactDetailsChanged = true),
+        address = Seq(updatedAddress))
     }
   }
 
@@ -74,7 +73,7 @@ class SubscriptionDataAdapterService @Inject()(atedConnector: AtedConnector) {
     getCorrespondenceAddress(Some(oldData)).map { foundCorrespondence =>
       val editedContactDetail = foundCorrespondence.contactDetails.map(_.copy(phoneNumber = Some(editedContactDetails.phoneNumber)))
       val postCode = foundCorrespondence.addressDetails.postalCode match {
-        case Some(pc) if(pc == "") => None
+        case Some(pc) if pc == "" => None
         case Some(pc) => Some(pc)
         case None => None
       }

--- a/test/services/SubscriptionDataAdapterServiceSpec.scala
+++ b/test/services/SubscriptionDataAdapterServiceSpec.scala
@@ -28,6 +28,7 @@ import play.api.libs.json.{JsValue, Json}
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.logging.SessionId
 import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier, HttpResponse, InternalServerException}
+import utils.AtedConstants
 
 import scala.concurrent.Future
 
@@ -265,6 +266,8 @@ class SubscriptionDataAdapterServiceSpec extends PlaySpec with MockitoSugar{
         val response: Option[UpdateSubscriptionDataRequest] = testSubscriptionDataAdapterService
           .createEditEmailWithConsentRequest(successResponse, updatedDetails)
         response.isDefined must be(true)
+        response.get.address.exists(addr => addr.addressDetails.addressType == AtedConstants.AddressTypeCorrespondence) must be(true)
+        response.get.address.size mustBe 1
         response.get.changeIndicators.contactDetailsChanged must be(true)
         response.get.changeIndicators.nameChanged must be(false)
         response.get.changeIndicators.correspondenceChanged must be(false)


### PR DESCRIPTION
# DL-3295 Only send one address block for editing email

**Bug fix**

* Editing the email address of an ATED subscription now no longer sends both address blocks, as this is invalid in the API schema.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date