### PR TITLE
DL-2771 Order returns in the current year

### DIFF
--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -45,7 +45,9 @@
 
     <logger name="com.ning.http.client" level="WARN"/>
     <logger name="org.asynchttpclient.netty.channel.DefaultChannelPool" level="WARN"/>
+    <logger name="play.shaded.ahc.org.asynchttpclient.netty.channel.DefaultChannelPool" level="WARN"/>
     <logger name="play.core.netty.utils.ServerCookieDecoder" level="WARN"/>
+    <logger name="play.shaded.ahc.org.asynchttpclient.netty.handler.HttpHandler" level="WARN"/>
     <logger name="org.asynchttpclient.netty" level="WARN"/>
 
     <logger name="uk.gov" level="INFO"/>

--- a/test/models/SummaryReturnsModelSpec.scala
+++ b/test/models/SummaryReturnsModelSpec.scala
@@ -31,7 +31,7 @@ class SummaryReturnsModelSpec extends PlaySpec with GuiceOneServerPerSuite with 
 
     "read correctly from json" in {
 
-      allReturnsJson(true, true)
+      allReturnsJson()
         .as[SummaryReturnsModel] must be(summaryReturnsModel(periodKey = currentTaxYear))
 
     }

--- a/test/utils/TestModels.scala
+++ b/test/utils/TestModels.scala
@@ -19,7 +19,7 @@ package utils
 import config.ApplicationConfig
 import models._
 import org.joda.time.LocalDate
-import play.api.libs.json.{JsObject, Json}
+import play.api.libs.json.{JsArray, JsObject, Json}
 import utils.AtedConstants._
 
 trait TestModels {
@@ -42,10 +42,10 @@ trait TestModels {
         faxNumber = Some("0223344556677"))),
       addressDetails = AddressDetails(AddressTypeCorrespondence, "addrLine1", "addrLine2", None, None, None, "GB"))}
 
-  def draftReturns1(periodKey: Int) = DraftReturns(periodKey, "1", "desc", Some(BigDecimal(100.00)), TypeChangeLiabilityDraft)
-  def draftReturns2(periodKey: Int) = DraftReturns(periodKey, "", "some relief", None, TypeReliefDraft)
-  def draftReturns3(periodKey: Int) = DraftReturns(periodKey, "1", "liability draft", Some(BigDecimal(100.00)), TypeLiabilityDraft)
-  def draftReturns4(periodKey: Int) = DraftReturns(periodKey, "", "dispose liability draft", None, TypeDisposeLiabilityDraft)
+  def draftReturns1(periodKey: Int) = DraftReturns(periodKey, "1", "desc", Some(BigDecimal(100.00)), TypeChangeLiabilityDraft, LocalDate.now())
+  def draftReturns2(periodKey: Int) = DraftReturns(periodKey, "", "some relief", None, TypeReliefDraft, LocalDate.now())
+  def draftReturns3(periodKey: Int) = DraftReturns(periodKey, "1", "liability draft", Some(BigDecimal(100.00)), TypeLiabilityDraft, LocalDate.now())
+  def draftReturns4(periodKey: Int) = DraftReturns(periodKey, "", "dispose liability draft", None, TypeDisposeLiabilityDraft, LocalDate.now())
 
   val submittedReliefReturns1 = SubmittedReliefReturns(
     formBundleNo1, "some relief", new LocalDate("2015-05-05"), new LocalDate("2015-05-05"), new LocalDate("2015-05-05"))
@@ -58,7 +58,7 @@ trait TestModels {
     new LocalDate("2015-05-05"), new LocalDate("2015-05-05"), changeAllowed = false, "payment-ref"
   )
 
-  def submittedReturns(periodKey: Int, withPastReturns: Boolean = false) =
+  def submittedReturns(periodKey: Int, withPastReturns: Boolean = false): SubmittedReturns =
 
     if(withPastReturns){
       SubmittedReturns(periodKey, Seq(submittedReliefReturns1), Seq(submittedLiabilityReturns1), Seq(previousReturns))
@@ -66,23 +66,25 @@ trait TestModels {
       SubmittedReturns(periodKey, Seq(submittedReliefReturns1), Seq(submittedLiabilityReturns1), Seq())
     }
 
-  def draftReturnsJson(periodKey: Int) = Json.arr(
+  def draftReturnsJson(periodKey: Int): JsArray = Json.arr(
     Json.obj(
       "periodKey" -> periodKey,
       "id" -> "1",
       "description" -> "desc",
       "charge" -> 100.0,
-      "returnType" -> "Change_Liability"
+      "returnType" -> "Change_Liability",
+      "lastModified" -> LocalDate.now().toString()
     ),
     Json.obj(
       "periodKey" -> periodKey,
       "id" -> "",
       "description" -> "some relief",
-      "returnType" -> "Relief"
+      "returnType" -> "Relief",
+      "lastModified" -> LocalDate.now().toString()
     )
   )
 
-  def submittedReturnsJson(periodKey: Int) = Json.obj(
+  def submittedReturnsJson(periodKey: Int): JsObject = Json.obj(
     "periodKey" -> periodKey,
     "reliefReturns" -> Json.arr(
       Json.obj(

--- a/test/views/periodSummaryPastReturnsSpec.scala
+++ b/test/views/periodSummaryPastReturnsSpec.scala
@@ -41,8 +41,8 @@ implicit lazy val authContext: StandardAuthRetrievals = organisationStandardRetr
   val formBundleNo1: String = "123456789012"
   val formBundleNo2: String = "123456789013"
   val formBundleNo3: String = "123456789014"
-  val draftReturns1: DraftReturns = DraftReturns(2015, "1", "desc", Some(BigDecimal(100.00)), TypeChangeLiabilityDraft)
-  val draftReturns2: DraftReturns = DraftReturns(2015, "", "some relief", None, TypeReliefDraft)
+  val draftReturns1: DraftReturns = DraftReturns(2015, "1", "desc", Some(BigDecimal(100.00)), TypeChangeLiabilityDraft, LocalDate.now())
+  val draftReturns2: DraftReturns = DraftReturns(2015, "", "some relief", None, TypeReliefDraft, LocalDate.now())
   val submittedReliefReturns1: SubmittedReliefReturns = SubmittedReliefReturns(formBundleNo1, "some relief",
     new LocalDate("2015-05-05"), new LocalDate("2015-05-05"), new LocalDate("2015-05-05"))
   val submittedReliefReturns1Older = SubmittedReliefReturns(formBundleNo1, "some relief",

--- a/test/views/periodSummarySpec.scala
+++ b/test/views/periodSummarySpec.scala
@@ -42,9 +42,9 @@ class periodSummarySpec extends FeatureSpec with GuiceOneAppPerSuite with Mockit
   val formBundleNo1 = "123456789012"
   val formBundleNo2 = "123456789013"
   val formBundleNo3 = "123456789014"
-
-  val draftReturns1 = DraftReturns(2015, "1", "desc", Some(BigDecimal(100.00)), TypeLiabilityDraft)
-  val draftReturns2 = DraftReturns(2015, "", "some relief", None, TypeReliefDraft)
+  
+  val draftReturns1 = DraftReturns(2015, "1", "desc", Some(BigDecimal(100.00)), TypeLiabilityDraft, LocalDate.now())
+  val draftReturns2 = DraftReturns(2015, "", "some relief", None, TypeReliefDraft, LocalDate.now())
 
   val submittedReliefReturns1 = SubmittedReliefReturns(formBundleNo1, "some relief",
     new LocalDate("2015-05-05"), new LocalDate("2015-05-05"), new LocalDate("2015-05-05"))


### PR DESCRIPTION
# DL-2771 Order returns in the current year

**New feature**

* Altered the ordering of returns on the main summary to also order based on last modified time (and alphabetically for reliefs)

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date