### PR TITLE
DL-3769: Corrected dispose liability return summary

### DIFF
--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -17,8 +17,8 @@
 package config
 
 import config.{ConfigKeys => Keys}
-import javax.inject.{Inject, Singleton}
-import play.api.{Configuration, Environment}
+import javax.inject.Inject
+import play.api.Environment
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import utils.CountryCodeUtils
 

--- a/app/config/AtedHeaderCarrierForPartialsConverter.scala
+++ b/app/config/AtedHeaderCarrierForPartialsConverter.scala
@@ -17,7 +17,6 @@
 package config
 
 import javax.inject.{Inject, Singleton}
-import uk.gov.hmrc.crypto.PlainText
 import uk.gov.hmrc.play.bootstrap.filters.frontend.crypto.SessionCookieCrypto
 import uk.gov.hmrc.play.partials.HeaderCarrierForPartialsConverter
 

--- a/app/models/AtedModels.scala
+++ b/app/models/AtedModels.scala
@@ -66,6 +66,28 @@ case class DisposeLiabilityReturn(id: String,
 
 object DisposeLiabilityReturn {
   implicit val formats: OFormat[DisposeLiabilityReturn] = Json.format[DisposeLiabilityReturn]
+
+  def isComplete(dlr: DisposeLiabilityReturn): Boolean = {
+    val addressProvided = dlr.formBundleReturn.propertyDetails.address.addressLine1 > ""
+    val dateProvided = dlr.disposeLiability.fold[Boolean](false)(_.dateOfDisposal.isDefined)
+    val bankDetailsSectionComplete = dlr.bankDetails.fold(false)(details =>
+      if(details.hasBankDetails){
+        bankDetailsComplete(details)
+      }else{
+        true
+      }
+    )
+
+    addressProvided && dateProvided && bankDetailsSectionComplete
+
+  }
+
+  def bankDetailsComplete(bdm: BankDetailsModel): Boolean = {
+    bdm.bankDetails.fold(false)(details =>
+      details.hasUKBankAccount.isDefined
+    )
+  }
+
 }
 
 case class CyaRow(

--- a/app/models/BankDetailModels.scala
+++ b/app/models/BankDetailModels.scala
@@ -117,7 +117,7 @@ object BankDetails {
 }
 
 
-case class BankDetailsModel(hasBankDetails: Boolean = false,
+case class BankDetailsModel(hasBankDetails: Boolean,
                             bankDetails: Option[BankDetails] = None)
 
 object BankDetailsModel {

--- a/app/utils/CountryCodeUtils.scala
+++ b/app/utils/CountryCodeUtils.scala
@@ -20,7 +20,7 @@ import java.util.PropertyResourceBundle
 
 import play.api.Environment
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.util.{Success, Try}
 
 trait CountryCodeUtils {
@@ -38,7 +38,7 @@ trait CountryCodeUtils {
     }).getOrElse(throw new RuntimeException("[CountryCodeUtils] Could not retrieve property bundle"))
 
   def getIsoCodeTupleList: List[(String, String)] = {
-    resourceStream.getKeys.toList.map(key => (key, resourceStream.getString(key))).sortBy{case (_,v) => v}
+    resourceStream.getKeys.asScala.toList.map(key => (key, resourceStream.getString(key))).sortBy{case (_,v) => v}
   }
 
 

--- a/app/views/editLiability/disposeLiabilitySummary.scala.html
+++ b/app/views/editLiability/disposeLiabilitySummary.scala.html
@@ -22,7 +22,7 @@
 @import _root_.utils.PeriodUtils._
 @import views.html.helpers._
 
-@incomplete = {@messages("ated.label.incomplete")}
+@incomplete = {@Html("<span class=\"status\">" + messages("ated.label.incomplete") + "</span>")}
 
 @analyticsJs = {
   ga('set', 'page', document.location.pathname.replace(/[0-9]/g ,'').replace(/\/\//g, '/'));
@@ -38,19 +38,17 @@
 }
 
 @disposeLiabilityDate = {
-  @disposeLiability.disposeLiability.flatMap(x => x.dateOfDisposal.map(y => y.toString(messages("ated.date-format"))))
+  @disposeLiability.disposeLiability.map(x => x.dateOfDisposal.fold(
+    incomplete
+  )
+  (date => Html(date.toString(messages("ated.date-format"))))
+  )
 }
 
 @disposeLiabilityDateEdit = {
   <a href="@controllers.editLiability.routes.DisposePropertyController.editFromSummary(disposeLiability.id.toString)"   id="edit-property-disposal-date" data-journey-click="ated-frontend:click:edit-property-disposal-date">
     @messages("ated.edit") <span class="visuallyhidden">@messages("ated.dispose-property.summary.disposal-date-label")</span>
   </a>
-}
-
-@bankDetailsTypeOfAccountNONEEdit = {
-<a href="@controllers.editLiability.routes.DisposePropertyController.editFromSummary(disposeLiability.id.toString)" id="edit-bank-details-type" data-journey-click="ated-frontend:click:edit-bank-details">
-  @messages("ated.edit") <span class="visuallyhidden">@messages("ated.edit-liability.summary.bank-details.type-of-account")</span>
-</a>
 }
 
 @bankDetailsTypeOfAccountEdit = {
@@ -160,7 +158,7 @@
           CyaRow(
             cyaQuestion = "ated.edit-liability.summary.bank-details.type-of-account",
             cyaQuestionId = "type-of-account-label",
-            cyaAnswer = Html(messages("ated.label.incomplete")),
+            cyaAnswer = incomplete,
             cyaAnswerId = "type-of-account-value",
             cyaChange = Some(bankDetailsTypeOfAccountEdit)
           )
@@ -251,7 +249,7 @@
           CyaRow(
             cyaQuestion = "ated.edit-liability.summary.bank-details.supply-bank-details",
             cyaQuestionId = "supply-bank-label",
-            cyaAnswer = Html("<span class=\"status\">" + messages("ated.label.incomplete") + "</span>"),
+            cyaAnswer = incomplete,
             cyaAnswerId = "supply-bank-value",
             cyaChange = Some(bankDetailsIncompleteEdit)
           )
@@ -302,8 +300,9 @@
     <a href="@controllers.routes.AccountSummaryController.view()" id="saved-returns-link">@messages("ated.dispose-property.summary.save-as-draft-link")</a>
   </p>
 
-  @form(action=controllers.editLiability.routes.DisposeLiabilitySummaryController.submit(disposeLiability.id.toString)) {
-    <button class="button" id="submit" type="submit">@messages("ated.confirm-and-continue")</button>
+  @if(DisposeLiabilityReturn.isComplete(disposeLiability)) {
+    @form(action = controllers.editLiability.routes.DisposeLiabilitySummaryController.submit(disposeLiability.id.toString)) {
+      <button class="button" id="submit" type="submit">@messages("ated.confirm-and-continue")</button>
+    }
   }
-
 }

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,8 @@ lazy val scoverageSettings = {
     )
   }
 
+val silencerVersion = "1.7.0"
+
 lazy val microservice = Project(appName, file("."))
     .enablePlugins(Seq(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory) ++ plugins: _*)
     .settings(playSettings: _*)
@@ -52,7 +54,12 @@ lazy val microservice = Project(appName, file("."))
     .disablePlugins(JUnitXmlReportPlugin)
     .settings(
       resolvers += Resolver.bintrayRepo("hmrc", "releases"),
-      resolvers += Resolver.jcenterRepo
+      resolvers += Resolver.jcenterRepo,
+      scalacOptions += "-P:silencer:pathFilters=views;routes",
+      libraryDependencies ++= Seq(
+        compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),
+        "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.full
+      )
     )
     .disablePlugins(JUnitXmlReportPlugin)
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,7 +6,7 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     ws,
-    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.13.0",
+    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.14.0",
     "uk.gov.hmrc" %% "auth-client" % "3.0.0-play-26",
     "uk.gov.hmrc" %% "play-ui" % "8.11.0-play-26",
     "uk.gov.hmrc" %% "play-partials" % "6.11.0-play-26",

--- a/test/builders/DisposeLiabilityReturnBuilder.scala
+++ b/test/builders/DisposeLiabilityReturnBuilder.scala
@@ -32,11 +32,10 @@ object DisposeLiabilityReturnBuilder {
     val fReturn = FormBundleReturn("2015", fProperty, dateOfAcquisition = None, valueAtAcquisition = None, taxAvoidanceScheme = None, localAuthorityCode = None, professionalValuation = true, ninetyDayRuleApplies = false,
       dateOfSubmission = new LocalDate("2015-04-02"), liabilityAmount = BigDecimal(123.45), paymentReference = "payment-ref-123", lineItem = Seq())
 
-    DisposeLiabilityReturn(id = oldFormBundleNum, fReturn, Some(dispDate))
+    DisposeLiabilityReturn(id = oldFormBundleNum, fReturn, Some(dispDate), None, None)
   }
 
 
   def generateCalculated = DisposeCalculated(liabilityAmount = BigDecimal(2500.00), amountDueOrRefund = -500.00)
-
 
 }

--- a/test/builders/PropertyDetailsBuilder.scala
+++ b/test/builders/PropertyDetailsBuilder.scala
@@ -147,7 +147,7 @@ object PropertyDetailsBuilder {
 
   def getPropertyDetails(id: String,
                          postCode: Option[String] = None,
-                         liabilityAmount: Option[BigDecimal] = None)(implicit appConfig: ApplicationConfig): PropertyDetails = {
+                         liabilityAmount: Option[BigDecimal] = None): PropertyDetails = {
     val periodKey: Int = 2019
     PropertyDetails(
       id,

--- a/test/connectors/AddressLookupConnectorSpec.scala
+++ b/test/connectors/AddressLookupConnectorSpec.scala
@@ -69,7 +69,6 @@ class AddressLookupConnectorSpec extends PlaySpec with GuiceOneAppPerSuite with 
 
       "return nil if something goes wrong" in new Setup {
 
-        val response = List(addressLookupRecord)
         implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId(s"session-${UUID.randomUUID}")))
         when(mockHttp.GET[List[AddressLookupRecord]]
           (ArgumentMatchers.any())
@@ -96,7 +95,6 @@ class AddressLookupConnectorSpec extends PlaySpec with GuiceOneAppPerSuite with 
 
       "return None if something goes wrong" in new Setup {
 
-        val response = List(AddressLookupRecord("1", address))
         implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId(s"session-${UUID.randomUUID}")))
         when(mockHttp.GET[Option[AddressLookupRecord]]
           (ArgumentMatchers.any())

--- a/test/connectors/AgentClientMandateFrontendConnectorSpec.scala
+++ b/test/connectors/AgentClientMandateFrontendConnectorSpec.scala
@@ -53,7 +53,6 @@ class AgentClientMandateFrontendConnectorSpec extends PlaySpec with GuiceOneAppP
     "return the partial successfully" in new Setup {
       implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
       implicit val hc: HeaderCarrier = HeaderCarrier()
-      implicit val hcwc: HeaderCarrierForPartials = HeaderCarrierForPartials(hc,"")
       val html = "<h1>helloworld</h1>"
       when(mockHttp.GET[HttpResponse](any())(any(), any(), any()))
         .thenReturn(Future.successful(HttpResponse(OK, responseString = Some(html))))
@@ -65,7 +64,6 @@ class AgentClientMandateFrontendConnectorSpec extends PlaySpec with GuiceOneAppP
     "return no partial silently" in new Setup {
       implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
       implicit val hc: HeaderCarrier = HeaderCarrier()
-      implicit val hcwc: HeaderCarrierForPartials = HeaderCarrierForPartials(hc,"")
 
       when(mockHttp.GET[HttpResponse](any())(any(), any(), any()))
         .thenReturn(Future.successful(HttpResponse(NOT_FOUND)))
@@ -77,7 +75,6 @@ class AgentClientMandateFrontendConnectorSpec extends PlaySpec with GuiceOneAppP
     "return the client mandate details succcessfully" in new Setup {
       implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
       implicit val hc: HeaderCarrier = HeaderCarrier()
-      implicit val hcwc: HeaderCarrierForPartials = HeaderCarrierForPartials(hc,"")
       when(mockHttp.GET[HttpResponse](any())(any(), any(), any()))
         .thenReturn(Future.successful(HttpResponse(OK, responseString = Some(""))))
       val result: Future[HttpResponse] = testAgentClientMandateFrontendConnector.getClientDetails("clientId", "ated")

--- a/test/controllers/editLiability/BankDetailsControllerSpec.scala
+++ b/test/controllers/editLiability/BankDetailsControllerSpec.scala
@@ -116,7 +116,7 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
     "view - for authorised users" must {
 
       "navigate to bank details page, if liablity is retrieved" in new Setup {
-        val bankDetails: BankDetailsModel = BankDetailsModel()
+        val bankDetails: BankDetailsModel = BankDetailsModel(hasBankDetails = false)
         val changeLiabilityReturn: PropertyDetails = ChangeLiabilityReturnBuilder
           .generateChangeLiabilityReturn("12345678901").copy(bankDetails = Some(bankDetails))
         viewWithAuthorisedUser(Some(changeLiabilityReturn)) {
@@ -140,7 +140,7 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
 
     "save - for authorised user" must {
       "for invalid data, return BAD_REQUEST" in new Setup {
-        val bankDetails: BankDetailsModel = BankDetailsModel()
+        val bankDetails: BankDetailsModel = BankDetailsModel(hasBankDetails = false)
         val inputJson: JsValue = Json.toJson(bankDetails)
         when(mockBackLinkCache.fetchAndGetBackLink(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
         saveWithAuthorisedUser(inputJson) {

--- a/test/controllers/editLiability/DisposeLiabilityBankDetailsControllerSpec.scala
+++ b/test/controllers/editLiability/DisposeLiabilityBankDetailsControllerSpec.scala
@@ -133,7 +133,8 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
 
       "return a status of OK, when that liability return is found in cache or ETMP" in new Setup {
         val disposeLiabilityReturn: DisposeLiabilityReturn = DisposeLiabilityReturnBuilder
-          .generateDisposeLiabilityReturn("12345678901").copy(bankDetails = Some(BankDetailsModel()))
+          .generateDisposeLiabilityReturn("12345678901")
+          .copy(bankDetails = Some(BankDetailsModel(hasBankDetails = false)))
         viewWithAuthorisedUser(Some(disposeLiabilityReturn)) {
           result =>
             status(result) must be(OK)
@@ -157,7 +158,8 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
 
       "navigate to bank details page, if liablity is retrieved, show the summary back link" in new Setup {
         val disposeLiabilityReturn: DisposeLiabilityReturn = DisposeLiabilityReturnBuilder
-          .generateDisposeLiabilityReturn("12345678901").copy(bankDetails = Some(BankDetailsModel()))
+          .generateDisposeLiabilityReturn("12345678901")
+          .copy(bankDetails = Some(BankDetailsModel(hasBankDetails = false)))
         editFromSummary(Some(disposeLiabilityReturn)) {
           result =>
             status(result) must be(OK)

--- a/test/controllers/editLiability/DisposeLiabilityHasBankDetailsControllerSpec.scala
+++ b/test/controllers/editLiability/DisposeLiabilityHasBankDetailsControllerSpec.scala
@@ -136,7 +136,8 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
 
       "return a status of OK, when that liability return is found in cache or ETMP" in new Setup {
         val disposeLiabilityReturn: DisposeLiabilityReturn = DisposeLiabilityReturnBuilder
-          .generateDisposeLiabilityReturn("12345678901").copy(bankDetails = Some(BankDetailsModel()))
+          .generateDisposeLiabilityReturn("12345678901")
+          .copy(bankDetails = Some(BankDetailsModel(hasBankDetails = false)))
         viewWithAuthorisedUser(Some(disposeLiabilityReturn)) {
           result =>
             status(result) must be(OK)
@@ -161,7 +162,8 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
 
       "return a status of OK and have the back link set to the summary page" in new Setup {
         val disposeLiabilityReturn: DisposeLiabilityReturn = DisposeLiabilityReturnBuilder
-          .generateDisposeLiabilityReturn("12345678901").copy(bankDetails = Some(BankDetailsModel()))
+          .generateDisposeLiabilityReturn("12345678901")
+          .copy(bankDetails = Some(BankDetailsModel(hasBankDetails = false)))
         editFromSummary(Some(disposeLiabilityReturn)) {
           result =>
             status(result) must be(OK)

--- a/test/controllers/editLiability/DisposeLiabilitySummaryControllerSpec.scala
+++ b/test/controllers/editLiability/DisposeLiabilitySummaryControllerSpec.scala
@@ -155,7 +155,6 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
             assert(document.getElementById("ated-charge-value") === null)
             document.getElementById("print-friendly-edit-liability-link").text() must be("Print this return")
             document.getElementById("saved-returns-link").text() must be("Save as draft")
-            document.getElementById("submit").text() must be("Confirm and continue")
         }
       }
 

--- a/test/controllers/editLiability/DisposePropertyControllerSpec.scala
+++ b/test/controllers/editLiability/DisposePropertyControllerSpec.scala
@@ -193,7 +193,8 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
 
       "return a status of OK and have the back link set to the summary page" in new Setup {
         val disposeLiabilityReturn: DisposeLiabilityReturn = DisposeLiabilityReturnBuilder
-          .generateDisposeLiabilityReturn("12345678901").copy(bankDetails = Some(BankDetailsModel()))
+          .generateDisposeLiabilityReturn("12345678901")
+          .copy(bankDetails = Some(BankDetailsModel(hasBankDetails = false)))
         editFromSummary(Some(disposeLiabilityReturn)) {
           result =>
             status(result) must be(OK)

--- a/test/controllers/editLiability/EditLiabilityDeclarationControllerSpec.scala
+++ b/test/controllers/editLiability/EditLiabilityDeclarationControllerSpec.scala
@@ -18,15 +18,13 @@ package controllers.editLiability
 
 import java.util.UUID
 
-import builders._
+import builders.{SessionBuilder, TitleBuilder, _}
 import config.ApplicationConfig
 import connectors.{BackLinkCacheConnector, DataCacheConnector}
 import controllers.auth.AuthAction
-import mocks.MockAppConfig
 import models._
 import org.joda.time.DateTime
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
@@ -37,34 +35,10 @@ import play.api.i18n.{Lang, MessagesApi, MessagesImpl}
 import play.api.mvc.{MessagesControllerComponents, Result}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import play.twirl.api.Html
 import services.{ChangeLiabilityReturnService, ServiceInfoService}
 import testhelpers.MockAuthUtil
 import uk.gov.hmrc.auth.core.AffinityGroup
 import uk.gov.hmrc.http.{HeaderCarrier, UserId}
-import utils.AtedConstants
-import views.html.BtaNavigationLinks
-import builders.{SessionBuilder, TitleBuilder}
-import config.ApplicationConfig
-import connectors.{AgentClientMandateFrontendConnector, BackLinkCacheConnector, DataCacheConnector}
-import controllers.auth.AuthAction
-import models.ReturnType
-import org.jsoup.Jsoup
-import org.mockito.ArgumentMatchers
-import org.mockito.Mockito._
-import org.scalatest.BeforeAndAfterEach
-import org.scalatestplus.mockito.MockitoSugar
-import org.scalatestplus.play.PlaySpec
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.i18n.{Lang, MessagesApi, MessagesImpl}
-import play.api.libs.json.{JsValue, Json}
-import play.api.mvc.{AnyContentAsJson, MessagesControllerComponents, Result}
-import play.api.test.FakeRequest
-import play.api.test.Helpers._
-import services._
-import testhelpers.MockAuthUtil
-import uk.gov.hmrc.auth.core.AffinityGroup
-import uk.gov.hmrc.http.HeaderCarrier
 import utils.AtedConstants
 import views.html.BtaNavigationLinks
 
@@ -129,7 +103,6 @@ class Setup {
 
   def viewWithAuthorisedDelegatedUser(x: Option[PropertyDetails] = None)(test: Future[Result] => Any) {
     val userId = s"user-${UUID.randomUUID}"
-    implicit val hc: HeaderCarrier = HeaderCarrier(userId = Some(UserId(userId)))
     val authMock = authResultDefault(AffinityGroup.Agent, defaultEnrolmentSet)
     setAuthMocks(authMock)
     when(mockDataCacheConnector.fetchAtedRefData[String](ArgumentMatchers.eq(AtedConstants.DelegatedClientAtedRefNumber))

--- a/test/controllers/editLiability/EditLiabilitySentControllerSpec.scala
+++ b/test/controllers/editLiability/EditLiabilitySentControllerSpec.scala
@@ -84,7 +84,6 @@ class Setup {
     val userId = s"user-${UUID.randomUUID}"
     val authMock = authResultDefault(AffinityGroup.Organisation, defaultEnrolmentSet)
     setAuthMocks(authMock)
-    implicit val hc: HeaderCarrier = HeaderCarrier()
     when(mockServiceInfoService.getPartial(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(btaNavigationLinksView()(messages,mockAppConfig)))
     when(mockDataCacheConnector.fetchAtedRefData[String](ArgumentMatchers.eq(AtedConstants.DelegatedClientAtedRefNumber))
       (ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some("XN1200000100001")))
@@ -98,7 +97,6 @@ class Setup {
     val userId = s"user-${UUID.randomUUID}"
     val authMock = authResultDefault(AffinityGroup.Organisation, defaultEnrolmentSet)
     setAuthMocks(authMock)
-    implicit val hc: HeaderCarrier = HeaderCarrier()
     when(mockDataCacheConnector.fetchAtedRefData[String](ArgumentMatchers.eq(AtedConstants.DelegatedClientAtedRefNumber))
       (ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some("XN1200000100001")))
     when(mockDataCacheConnector.fetchAndGetFormData[EditLiabilityReturnsResponseModel]

--- a/test/controllers/editLiability/HasBankDetailsControllerSpec.scala
+++ b/test/controllers/editLiability/HasBankDetailsControllerSpec.scala
@@ -126,7 +126,7 @@ class Setup {
     "view - for authorised users" must {
 
       "navigate to bank details page, if liability is retrieved" in new Setup {
-        val bankDetails = BankDetailsModel()
+        val bankDetails = BankDetailsModel(hasBankDetails = false)
         val changeLiabilityReturn: PropertyDetails = ChangeLiabilityReturnBuilder
           .generateChangeLiabilityReturn("12345678901").copy(bankDetails = Some(bankDetails))
         viewWithAuthorisedUser(Some(changeLiabilityReturn)) {
@@ -153,7 +153,7 @@ class Setup {
     "editFromSummary - for authorised users" must {
 
       "navigate to bank details page, if liability is retrieved, show the summary back link" in new Setup {
-        val bankDetails = BankDetailsModel()
+        val bankDetails = BankDetailsModel(hasBankDetails = false)
         val changeLiabilityReturn: PropertyDetails = ChangeLiabilityReturnBuilder
           .generateChangeLiabilityReturn("12345678901").copy(bankDetails = Some(bankDetails))
         editFromSummary(Some(changeLiabilityReturn)) {

--- a/test/controllers/propertyDetails/PropertyDetailsDeclarationControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsDeclarationControllerSpec.scala
@@ -112,7 +112,6 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
 
     def getWithAuthorisedDelegatedUser(test: Future[Result] => Any): Unit = {
       val userId = s"user-${UUID.randomUUID}"
-      implicit val hc: HeaderCarrier = HeaderCarrier(userId = Some(UserId(userId)))
       val authMock = authResultDefault(AffinityGroup.Agent, defaultEnrolmentSet)
       setAuthMocks(authMock)
       when(mockDataCacheConnector.fetchAtedRefData[String](ArgumentMatchers.eq(AtedConstants.DelegatedClientAtedRefNumber))

--- a/test/controllers/propertyDetails/PropertyDetailsSummaryControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsSummaryControllerSpec.scala
@@ -113,7 +113,6 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
         (ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some("XN1200000100001")))
       when(mockSubscriptionDataService.getOrganisationName(ArgumentMatchers.any(), ArgumentMatchers.any()))
         .thenReturn(Future.successful(Some(organisationName)))
-      implicit val hc: HeaderCarrier = HeaderCarrier()
 
       val result = testPropertyDetailsSummaryController.deleteDraft("123456", periodKey).apply(SessionBuilder.buildRequestWithSession(userId))
 

--- a/test/controllers/propertyDetails/SelectExistingReturnAddressControllerSpec.scala
+++ b/test/controllers/propertyDetails/SelectExistingReturnAddressControllerSpec.scala
@@ -296,8 +296,6 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
       "submitting an valid request should get the form bundle return and save in keystore" in new Setup {
         val formBundleProp = FormBundleProperty(BigDecimal(100), new LocalDate("2015-09-08"),
           new LocalDate("2015-10-12"), "Relief", Some("Property developers"))
-        val formBundleProp2 = FormBundleProperty(BigDecimal(200), new LocalDate("2015-10-12"),
-          new LocalDate("2015-12-12"), "Relief", Some("Property developers"))
         val formBundleAddress = FormBundleAddress("1 addressLine1", "addressLine2", Some("addressLine3"), Some("AddressLine4"), Some("XX11XX"), "GB")
         val formBundlePropertyDetails = FormBundlePropertyDetails(Some("title here"), formBundleAddress, Some("additional details"))
         val viewReturn = FormBundleReturn("2014", formBundlePropertyDetails,

--- a/test/controllers/reliefs/ReliefDeclarationControllerSpec.scala
+++ b/test/controllers/reliefs/ReliefDeclarationControllerSpec.scala
@@ -164,7 +164,6 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
       val userId = s"user-${UUID.randomUUID}"
       val authMock = authResultDefault(AffinityGroup.Agent, defaultEnrolmentSet)
       setAuthMocks(authMock)
-      implicit val hc: HeaderCarrier = HeaderCarrier(userId = Some(UserId(userId)))
       when(mockDataCacheConnector.fetchAtedRefData[String](ArgumentMatchers.eq(AtedConstants.DelegatedClientAtedRefNumber))
         (ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some("XN1200000100001")))
       when(mockBackLinkCacheConnector.fetchAndGetBackLink(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))

--- a/test/controllers/reliefs/ReliefsSentControllerSpec.scala
+++ b/test/controllers/reliefs/ReliefsSentControllerSpec.scala
@@ -86,7 +86,6 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
 
     def getWithAuthorisedUser(test: Future[Result] => Any) {
       val userId = s"user-${UUID.randomUUID}"
-      implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId(s"session-${UUID.randomUUID}")))
       val authMock = authResultDefault(AffinityGroup.Organisation, defaultEnrolmentSet)
       setAuthMocks(authMock)
       when(mockServiceInfoService.getPartial(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(btaNavigationLinksView()(messages,mockAppConfig)))
@@ -102,7 +101,6 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
 
     def getPrintFriendlyWithAuthorisedUser(test: Future[Result] => Any) {
       val userId = s"user-${UUID.randomUUID}"
-      implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId(s"session-${UUID.randomUUID}")))
       val authMock = authResultDefault(AffinityGroup.Organisation, defaultEnrolmentSet)
       setAuthMocks(authMock)
       when(mockReliefsService.retrieveDraftReliefs(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(None))
@@ -119,7 +117,6 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
 
     def getWithAuthorisedUserNoReliefs(test: Future[Result] => Any) {
       val userId = s"user-${UUID.randomUUID}"
-      implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId(s"session-${UUID.randomUUID}")))
       val authMock = authResultDefault(AffinityGroup.Organisation, defaultEnrolmentSet)
       setAuthMocks(authMock)
       when(mockServiceInfoService.getPartial(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(btaNavigationLinksView()(messages,mockAppConfig)))

--- a/test/controllers/reliefs/ReliefsSummaryControllerSpec.scala
+++ b/test/controllers/reliefs/ReliefsSummaryControllerSpec.scala
@@ -146,7 +146,6 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
       val userId = s"user-${UUID.randomUUID}"
       val authMock = authResultDefault(AffinityGroup.Organisation, defaultEnrolmentSet)
       setAuthMocks(authMock)
-      implicit val hc: HeaderCarrier = HeaderCarrier()
 
       val result = testReliefsSummaryController.deleteDraft(periodKey).apply(SessionBuilder.buildRequestWithSession(userId))
       test(result)

--- a/test/models/AtedModelsSpec.scala
+++ b/test/models/AtedModelsSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import builders.DisposeLiabilityReturnBuilder
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+
+class AtedModelsSpec extends PlaySpec with GuiceOneServerPerSuite {
+
+  "DisposeLiabilityReturn.isComplete" should {
+
+    "return true if disposal date, address and UK bank account details have been provided" in {
+
+        val ukBankDetails: DisposeLiabilityReturn = DisposeLiabilityReturnBuilder
+          .generateDisposeLiabilityReturn("12345678901").copy(
+          bankDetails = Some(
+            BankDetailsModel(hasBankDetails = true, Some(BankDetails(Some(true),
+              Some("Account name"), Some("87686787"), Some(SortCode("12", "12", "12")))))
+        ))
+
+      println(ukBankDetails)
+
+        DisposeLiabilityReturn.isComplete(ukBankDetails) must be(true)
+
+    }
+
+    "return true if disposal date, address and non-UK bank account details have been provided" in {
+
+      val nonUkBankDetails: DisposeLiabilityReturn = DisposeLiabilityReturnBuilder
+        .generateDisposeLiabilityReturn("12345678901").copy(
+        bankDetails = Some(
+          BankDetailsModel(hasBankDetails = true, bankDetails = Some(BankDetails(hasUKBankAccount = Some(false),
+            accountName = Some("Account name"), bicSwiftCode = Some(BicSwiftCode("87686787")), iban = Some(Iban("121212")))))
+        )
+        )
+
+      println(nonUkBankDetails)
+        DisposeLiabilityReturn.isComplete(nonUkBankDetails) must be(true)
+
+    }
+
+    "return false if uk bank account question has not been answered" in {
+
+      val missingBankDetails: DisposeLiabilityReturn = DisposeLiabilityReturnBuilder
+        .generateDisposeLiabilityReturn("12345678901").copy(
+        bankDetails = None
+      )
+
+      DisposeLiabilityReturn.isComplete(missingBankDetails) must be(false)
+
+    }
+
+  }
+}

--- a/test/services/PropertyDetailsServiceSpec.scala
+++ b/test/services/PropertyDetailsServiceSpec.scala
@@ -457,7 +457,7 @@ class PropertyDetailsServiceSpec extends PlaySpec with GuiceOneServerPerSuite wi
           .thenReturn(Future.successful(successResponse.as[SubmitReturnsResponse]))
 
         val result: Future[HttpResponse] = testPropertyDetailsService.submitDraftPropertyDetails("1")
-        val response: HttpResponse = await(result)
+        await(result)
         verify(mockDataCacheConnector, times(1)).clearCache()(ArgumentMatchers.any())
         verify(mockDataCacheConnector, times(1)).saveFormData(ArgumentMatchers.any(),ArgumentMatchers.any())(ArgumentMatchers.any(),ArgumentMatchers.any(),ArgumentMatchers.any())
       }
@@ -472,7 +472,7 @@ class PropertyDetailsServiceSpec extends PlaySpec with GuiceOneServerPerSuite wi
            .thenReturn(Future.successful(HttpResponse(OK, Some(successResponse))))
 
          val result: Future[HttpResponse] = testPropertyDetailsService.clearDraftReliefs("AB12345")
-         val response: HttpResponse = await(result)
+         await(result)
          verify(mockPropertyDetailsConnector, times(1)).deleteDraftChargeable(ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
        }
     }
@@ -485,7 +485,7 @@ class PropertyDetailsServiceSpec extends PlaySpec with GuiceOneServerPerSuite wi
           .thenReturn(Future.successful(HttpResponse(OK, Some(successResponse))))
 
         val result: Future[Boolean] = testPropertyDetailsService.validateCalculateDraftPropertyDetails("AB12345", true)
-        val response: Boolean = await(result)
+        await(result)
         verify(mockPropertyDetailsConnector, times(1)).retrieveDraftPropertyDetails(ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
       }
     }

--- a/test/services/SubscriptionDataAdapterServiceSpec.scala
+++ b/test/services/SubscriptionDataAdapterServiceSpec.scala
@@ -235,7 +235,6 @@ class SubscriptionDataAdapterServiceSpec extends PlaySpec with MockitoSugar{
           when(mockAtedConnector.updateSubscriptionData(any())(any(), any()))
             .thenReturn(Future.successful(HttpResponse(BAD_REQUEST, None)))
 
-          val updateContactDetails: ContactDetails = ContactDetails()
           val result: Future[Option[UpdateSubscriptionDataRequest]] = testSubscriptionDataAdapterService.updateSubscriptionData(updateSubscriptionData)
           val addressDetails: Option[UpdateSubscriptionDataRequest] = await(result)
           addressDetails.isDefined must be(false)
@@ -246,7 +245,7 @@ class SubscriptionDataAdapterServiceSpec extends PlaySpec with MockitoSugar{
             .thenReturn(Future.successful(HttpResponse(OK, None)))
 
           val result: Future[Option[UpdateSubscriptionDataRequest]] = testSubscriptionDataAdapterService.updateSubscriptionData(updateSubscriptionData)
-          val addressDetails: Option[UpdateSubscriptionDataRequest] = await(result)
+          await(result)
         }
       }
     }

--- a/test/services/SubscriptionDataServiceSpec.scala
+++ b/test/services/SubscriptionDataServiceSpec.scala
@@ -229,7 +229,6 @@ class SubscriptionDataServiceSpec extends PlaySpec with MockitoSugar with Before
       val cacheDataResponse = CachedData(SubscriptionData("XA0001234567899", "BusinessName", address = List(), emailConsent = Some(true)))
 
       "return None we have no data to update" in new Setup {
-        val updatedContactDetails: ContactDetails = ContactDetails()
 
         when(mockDataCacheConnector.fetchAndGetFormData[CachedData](eqTo(RetrieveSubscriptionDataId))(any(), any(), eqTo(CachedData.formats)))
           .thenReturn(Future.successful(Some(cacheDataResponse)))
@@ -249,7 +248,6 @@ class SubscriptionDataServiceSpec extends PlaySpec with MockitoSugar with Before
       }
 
       "save the data and clear the cache if it was successful" in new Setup {
-        val updatedContactDetails: ContactDetails = ContactDetails()
 
         when(mockDataCacheConnector.fetchAndGetFormData[CachedData](eqTo(RetrieveSubscriptionDataId))(any(), any(), eqTo(CachedData.formats)))
           .thenReturn(Future.successful(Some(cacheDataResponse)))

--- a/test/views/editLiability/disposeLiabilitySummarySpec.scala
+++ b/test/views/editLiability/disposeLiabilitySummarySpec.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.editLiability
+
+import builders.ChangeLiabilityReturnBuilder
+import config.ApplicationConfig
+import models.{BankDetails, BankDetailsModel, DisposeLiability, DisposeLiabilityReturn, SortCode, StandardAuthRetrievals}
+import org.joda.time.LocalDate
+import org.jsoup.Jsoup
+import org.scalatest.BeforeAndAfterEach
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.i18n.{Messages, MessagesApi}
+import play.api.test.FakeRequest
+import play.twirl.api.Html
+import testhelpers.MockAuthUtil
+import uk.gov.hmrc.play.test.UnitSpec
+
+class disposeLiabilitySummarySpec extends UnitSpec with GuiceOneAppPerSuite
+  with BeforeAndAfterEach with MockAuthUtil {
+
+  implicit val mockAppConfig: ApplicationConfig = app.injector.instanceOf[ApplicationConfig]
+  implicit val request = FakeRequest()
+  implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(request)
+  implicit lazy val authContext: StandardAuthRetrievals = organisationStandardRetrievals
+
+  val bankDetailsYesButNoDetails: Option[BankDetailsModel] = Some(BankDetailsModel(hasBankDetails = true, bankDetails = None))
+  val completedBankDetails: Option[BankDetailsModel] = Some(BankDetailsModel(hasBankDetails = true,
+    bankDetails = Some(BankDetails(hasUKBankAccount = Some(true),
+      accountName = Some("Account name"),
+      accountNumber = Some("12312312"),
+      sortCode = Some(SortCode("12","12","12")))))
+  )
+
+  def disposeLiabilityReturn(bankDetails: Option[BankDetailsModel],
+                             disposalDate: Option[LocalDate] = Some(LocalDate.parse("2020-01-01"))
+                            ): DisposeLiabilityReturn = DisposeLiabilityReturn(
+    id = "123",
+    formBundleReturn = ChangeLiabilityReturnBuilder.generateFormBundleReturn,
+    disposeLiability = Some(DisposeLiability(dateOfDisposal = disposalDate, periodKey = 2020)),
+    calculated = None,
+    bankDetails = bankDetails
+  )
+
+  "disposeLiabilitySummary" should {
+    "hide the submit button and show incomplete for bank details" when {
+      "the user has not answered the bank details question" in {
+        val html = views.html.editLiability.disposeLiabilitySummary(disposeLiabilityReturn(None), Html(""), Some("http://backLink"))
+        val document = Jsoup.parse(html.toString())
+        assert(document.getElementsByClass("button").size() === 0)
+        assert(document.getElementById("supply-bank-value").text() === "INCOMPLETE")
+      }
+
+      "the user has answered yes to the bank details question but not provided bank details" in {
+        val html = views.html.editLiability.disposeLiabilitySummary(disposeLiabilityReturn(bankDetailsYesButNoDetails),
+          Html(""), Some("http://backLink"))
+        val document = Jsoup.parse(html.toString())
+        assert(document.getElementsByClass("button").size() === 0)
+        assert(document.getElementById("type-of-account-value").text() === "INCOMPLETE")
+      }
+    }
+
+    "show the submit button" when {
+      "all required disposal details have been provided" in {
+        val html = views.html.editLiability.disposeLiabilitySummary(disposeLiabilityReturn(completedBankDetails),
+          Html(""), Some("http://backLink"))
+        val document = Jsoup.parse(html.toString())
+        assert(document.getElementsByClass("button").size() === 1)
+      }
+    }
+
+    "show incomplete next to the disposal date" when {
+      "the disposal date has not been provided" in {
+        val html = views.html.editLiability.disposeLiabilitySummary(disposeLiabilityReturn(completedBankDetails, None),
+          Html(""), Some("http://backLink"))
+        val document = Jsoup.parse(html.toString())
+        assert(document.getElementById("property-title-disposal-date").text() === "INCOMPLETE")
+      }
+    }
+  }
+}

--- a/test/views/editLiability/editLiabilitySummarySpec.scala
+++ b/test/views/editLiability/editLiabilitySummarySpec.scala
@@ -153,7 +153,7 @@ class editLiabilitySummarySpec extends FeatureSpec with GuiceOneServerPerSuite w
       assert(document.getElementById("backLinkHref").attr("href") === "http://backLink")
     }
 
-    scenario("Futher Charge the basic summary with no periods") {
+    scenario("Further Charge the basic summary with no periods") {
 
       Given("the client is creating a new liability and want to add multiple periods")
       When("The user views the page")

--- a/test/views/propertyDetails/periodChooseReliefSpec.scala
+++ b/test/views/propertyDetails/periodChooseReliefSpec.scala
@@ -46,8 +46,6 @@ feature("The user can add a period that the property is in relief") {
       Given("the client is adding a relief")
       When("The user views the page")
 
-      val periodStartDate = new LocalDate("2015-01-01")
-      val periodEndDate = new LocalDate("2016-02-02")
       val html = views.html.propertyDetails.periodChooseRelief("1", 2015, periodChooseReliefForm, Html(""), Some("backLink"))
 
       val document = Jsoup.parse(html.toString())
@@ -88,9 +86,7 @@ feature("The user can add a period that the property is in relief") {
 
       Given("the client is adding a relief")
       When("The user views the page")
-
-      val periodStartDate = new LocalDate("2015-01-01")
-      val periodEndDate = new LocalDate("2016-02-02")
+      
       val html = views.html.propertyDetails.periodChooseRelief("1",
         2015, periodChooseReliefForm.fill(PeriodChooseRelief(ReliefsUtils.RentalBusinessDesc)), Html(""), Some("http://backLink"))
 


### PR DESCRIPTION
DL-3769: Corrected dispose liability return summary
- now shows INCOMPLETE next to missing date of disposal and bank details
- submit button not available until all disposal details have been provided, preventing the user from submitting the disposal

Not sure about acceptance criteria 3 and run out of time to look into it but worth a check if these changes above have fixed it in QA.
(the status of the disposal changes to submitted after submission (currently it stays as draft after successful submission)

## Checklist

*Reviewee* (David Thornton)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date