### PR TITLE
DL-4121 Removed SessionKeys references

### DIFF
--- a/test/builders/SessionBuilder.scala
+++ b/test/builders/SessionBuilder.scala
@@ -20,49 +20,48 @@ import java.util.UUID
 
 import play.api.mvc.{AnyContentAsFormUrlEncoded, AnyContentAsJson}
 import play.api.test.FakeRequest
-import uk.gov.hmrc.http.SessionKeys
 
 object SessionBuilder {
 
-  val TOKEN = "token" // this is because SessionKeys.token gives warning
+  val TOKEN = "token"
 
   def updateRequestWithSession(fakeRequest: FakeRequest[AnyContentAsJson], userId: String): FakeRequest[AnyContentAsJson] = {
     val sessionId = s"session-${UUID.randomUUID}"
     fakeRequest.withSession(
-      SessionKeys.sessionId -> sessionId,
+      "sessionId" -> sessionId,
       TOKEN -> "RANDOMTOKEN",
-      SessionKeys.userId -> userId)
+      "userId" -> userId)
   }
 
 
   def updateRequestFormWithSession(fakeRequest: FakeRequest[AnyContentAsFormUrlEncoded], userId: String): FakeRequest[AnyContentAsFormUrlEncoded] = {
     val sessionId = s"session-${UUID.randomUUID}"
     fakeRequest.withSession(
-      SessionKeys.sessionId -> sessionId,
+      "sessionId" -> sessionId,
       TOKEN -> "RANDOMTOKEN",
-      SessionKeys.userId -> userId)
+      "userId" -> userId)
   }
 
   def buildRequestWithSession(userId: String) = {
     val sessionId = s"session-${UUID.randomUUID}"
     FakeRequest().withSession(
-      SessionKeys.sessionId -> sessionId,
+      "sessionId" -> sessionId,
       TOKEN -> "RANDOMTOKEN",
-      SessionKeys.userId -> userId)
+      "userId" -> userId)
   }
 
   def buildRequestWithSessionDelegation(userId: String) = {
     val sessionId = s"session-${UUID.randomUUID}"
     FakeRequest().withSession(
-      SessionKeys.sessionId -> sessionId,
+      "sessionId" -> sessionId,
       TOKEN -> "RANDOMTOKEN",
       "delegationState" -> "On",
-      SessionKeys.userId -> userId)
+      "userId" -> userId)
   }
 
   def buildRequestWithSessionNoUser = {
     val sessionId = s"session-${UUID.randomUUID}"
     FakeRequest().withSession(
-      SessionKeys.sessionId -> sessionId)
+      "sessionId" -> sessionId)
   }
 }

--- a/test/controllers/ControllerBaseSpec.scala
+++ b/test/controllers/ControllerBaseSpec.scala
@@ -30,7 +30,6 @@ import play.api.inject.Injector
 import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded, MessagesControllerComponents}
 import play.api.test.FakeRequest
 import testhelpers.TestUtil
-import uk.gov.hmrc.http.{SessionKeys => GovUKSessionKeys}
 
 import scala.concurrent.ExecutionContext
 
@@ -52,8 +51,8 @@ class ControllerBaseSpec extends PlaySpec with MockFactory with GuiceOneAppPerSu
 
 
   lazy val fakeRequestWithSession: FakeRequest[AnyContentAsEmpty.type] = fakeRequest.withSession(
-    GovUKSessionKeys.lastRequestTimestamp -> "1498236506662",
-    GovUKSessionKeys.authToken -> "Bearer Token",
+    "ts" -> "1498236506662",
+    "authToken" -> "Bearer Token",
     migrationToETMP -> "2018-01-01"
   )
 


### PR DESCRIPTION
# DL-4121 Removed SessionKeys references

**Bug fix**

* Removed deprecated references to SessionKeys in ated-frontend

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date