### PR TITLE
DL-4515: Added pre-population to edit return type page

### DIFF
--- a/app/controllers/BackLinkController.scala
+++ b/app/controllers/BackLinkController.scala
@@ -29,19 +29,19 @@ trait BackLinkController {
   val controllerId: String
   val backLinkCacheConnector: BackLinkCacheConnector
 
-  def setBackLink(pageId: String, returnUrl: Option[String])(implicit hc: HeaderCarrier) : Future[Option[String]] = {
+  def setBackLink(pageId: String, returnUrl: Option[String])(implicit hc: HeaderCarrier): Future[Option[String]] = {
     backLinkCacheConnector.saveBackLink(pageId, returnUrl)
   }
 
-  def getBackLink(pageId: String)(implicit hc: HeaderCarrier):Future[Option[String]] = {
+  def getBackLink(pageId: String)(implicit hc: HeaderCarrier): Future[Option[String]] = {
     backLinkCacheConnector.fetchAndGetBackLink(pageId)
   }
 
-  def currentBackLink(implicit hc: HeaderCarrier):Future[Option[String]] = {
+  def currentBackLink(implicit hc: HeaderCarrier): Future[Option[String]] = {
     getBackLink(controllerId)
   }
 
-  def clearBackLinks(pageIds: List[String]=Nil)(implicit hc: HeaderCarrier):Future[List[Option[String]]] = {
+  def clearBackLinks(pageIds: List[String] = Nil)(implicit hc: HeaderCarrier): Future[List[Option[String]]] = {
     pageIds match {
       case Nil => Future.successful(Nil)
       case _ => backLinkCacheConnector.clearBackLinks(pageIds)

--- a/test/builders/SessionBuilder.scala
+++ b/test/builders/SessionBuilder.scala
@@ -18,6 +18,7 @@ package builders
 
 import java.util.UUID
 
+import play.api.mvc.request.RequestTarget
 import play.api.mvc.{AnyContentAsFormUrlEncoded, AnyContentAsJson}
 import play.api.test.FakeRequest
 
@@ -42,12 +43,13 @@ object SessionBuilder {
       "userId" -> userId)
   }
 
-  def buildRequestWithSession(userId: String) = {
+  def buildRequestWithSession(userId: String, queryParams: Option[(String, Seq[String])] = None) = {
     val sessionId = s"session-${UUID.randomUUID}"
-    FakeRequest().withSession(
+    val fr = FakeRequest().withSession(
       "sessionId" -> sessionId,
       TOKEN -> "RANDOMTOKEN",
-      "userId" -> userId)
+      "userId" -> userId).withTarget(RequestTarget("", "", Map(queryParams.getOrElse("dummy" -> Seq()))))
+    fr
   }
 
   def buildRequestWithSessionDelegation(userId: String) = {


### PR DESCRIPTION
DL-4515: Added pre-population to edit return type page

## Checklist
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [x]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date