### PR TITLE
DL-3182 Moved acceptance tests to unit tests

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,14 +6,14 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     ws,
-    "uk.gov.hmrc" %% "bootstrap-frontend-play-27" % "3.0.0",
+    "uk.gov.hmrc" %% "bootstrap-frontend-play-27" % "3.2.0",
     "uk.gov.hmrc" %% "auth-client" % "3.2.0-play-27",
-    "uk.gov.hmrc" %% "play-ui" % "8.15.0-play-27",
-    "uk.gov.hmrc" %% "play-partials" % "7.0.0-play-27",
+    "uk.gov.hmrc" %% "play-ui" % "8.19.0-play-27",
+    "uk.gov.hmrc" %% "play-partials" % "7.1.0-play-27",
     "uk.gov.hmrc" %% "domain" % "5.10.0-play-27",
-    "uk.gov.hmrc" %% "http-caching-client" % "9.1.0-play-27",
+    "uk.gov.hmrc" %% "http-caching-client" % "9.2.0-play-27",
     "com.typesafe.play" %% "play-json-joda" % "2.7.4",
-    "uk.gov.hmrc" %% "govuk-template" % "5.59.0-play-27"
+    "uk.gov.hmrc" %% "govuk-template" % "5.60.0-play-27"
   )
 
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,11 +3,11 @@ import sbt._
 resolvers += Resolver.bintrayIvyRepo("hmrc", "sbt-plugin-releases")
 resolvers += Resolver.bintrayRepo("hmrc", "releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.10.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.12.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.5")
 

--- a/test/controllers/propertyDetails/PropertyDetailsAddressControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsAddressControllerSpec.scala
@@ -268,6 +268,7 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
               document.getElementById("backLinkHref").attr("href") must include("/ated/liability/confirm-address/view")
           }
         }
+
         "show the chargeable property details view with back link to EditLiabilityType" in new Setup {
           viewDataWithAuthorisedUserChangeReturn("1",PropertyDetailsBuilder.getPropertyDetailsWithFormBundleReturn("1"), false) {
             result =>

--- a/test/controllers/propertyDetails/PropertyDetailsSummaryControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsSummaryControllerSpec.scala
@@ -191,6 +191,16 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
               document.getElementById("address-line-2").text() must be("addr2")
               document.getElementById("address-line-3").text() must be("addr3")
               document.getElementById("address-line-4").text() must be("addr4")
+              document.getElementById("address-postcode").text() must be("123456")
+              document.getElementById("edit-property-address-details").attr("href") must include("/ated/liability/create/address/edit-summary/1")
+              document.getElementById("edit-property-title-details").attr("href") must include("/ated/liability/create/title/edit/1")
+              document.getElementById("edit-property-professionally-value-1").attr("href") must include("/ated/liability/create/owned-before/edit-summary/1")
+              document.getElementById("edit-property-professionally-valued-details-incomplete").attr("href") must include("/ated/liability/create/valued/edit/1")
+              document.getElementById("edit-dates-of-liablity-incomplete").attr("href") must include("/ated/liability/create/full-tax-period/edit-summary/1")
+              document.getElementById("edit-avoidance-scheme-header-incomplete").attr("href") must include("/ated/liability/create/tax-avoidance/edit-summary/1")
+              document.getElementById("edit-supporting-details").attr("href") must include("/ated/liability/create/supporting-info/edit-summary/1")
+              document.getElementById("print-friendly-liability-link").attr("href") must include("/ated/liability/create/summary/1/print")
+              document.getElementById("delete-draft").attr("href") must include("/ated/liability/delete/draft/1/2019")
           }
         }
       }


### PR DESCRIPTION
Unit Test coverage for Chargeable Property Declare Page

**New feature**

No changes made to PropertyDetailsAddressControllerSpec because the cache is already being tested.

Added tests into PropertyDetailsSummaryControllerSpec to test the edit links.

This allowed me to delete several lines of tests from the ated acceptance tests.

## Checklist

*Iyke* 
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [x]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date