### PR TITLE
DL-3190 adding test for Correspondence address validation

### DIFF
--- a/test/controllers/subscriptionData/CorrespondenceAddressControllerSpec.scala
+++ b/test/controllers/subscriptionData/CorrespondenceAddressControllerSpec.scala
@@ -434,6 +434,23 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
                 }
               }
 
+              "Postcode must entered if country code is UK" in new Setup {
+                val inputJson: JsValue = Json.parse(
+                  """{
+                    |"addressType": "Correspondence",
+                    |"addressLine1": "AddlineOne",
+                    |"addressLine2": "AddlineTwo",
+                    |"addressLine3": "",
+                    |"addressLine4": "",
+                    |"postalCode": "",
+                    |"countryCode": "GB"}""".stripMargin)
+                val addressDetails: AddressDetails = inputJson.as[AddressDetails]
+                submitWithAuthorisedUserSuccess(Some(addressDetails))(FakeRequest().withJsonBody(inputJson)) {
+                  result =>
+                    status(result) must be(BAD_REQUEST)
+                    contentAsString(result) must include("You must enter a UK postcode if UK is selected in the country field.")
+                }
+              }
 
               "Country Code must be selected" in new Setup {
                 val inputJson: JsValue = Json.parse(


### PR DESCRIPTION
DL-3190

**Maintenance** 

Adding additional test to check for validation message where UK country has been selected but no postcode added

## Checklist

*Reviewee* (Replace with your name)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date