### PR TITLE
DL-3191 adding error validation checks

### DIFF
--- a/test/controllers/editLiability/EditLiabilityDatesLiableControllerSpec.scala
+++ b/test/controllers/editLiability/EditLiabilityDatesLiableControllerSpec.scala
@@ -211,8 +211,16 @@ reset(mockPropertyDetailsService)
           submitWithAuthorisedUser(Nil) {
             result =>
               status(result) must be(BAD_REQUEST)
+
+              val document = Jsoup.parse(contentAsString(result))
+
+              assert(document.getElementById("startDate-error").text() === "There is a problem with the liability start date")
+              assert(document.getElementById("endDate-error").text() === "There is a problem with the liability end date")
+              assert(document.getElementById("startDate-error-0").text() === "You must enter a liability start date")
+              assert(document.getElementById("endDate-error-0").text() === "You must enter a liability end date")
           }
         }
+
         "for valid data forward to the TaxAvoidance Page" in new Setup {
           val formBody = List(
             ("startDate.day", "1"),

--- a/test/controllers/propertyDetails/PropertyDetailsSupportingInfoControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsSupportingInfoControllerSpec.scala
@@ -223,6 +223,7 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
               document.title() must be(TitleBuilder.buildTitle("Do you have any supporting information to add? (optional)"))
 
               document.getElementById("supportingInfo").attr("value") must be("")
+              assert(document.getElementById("supportingInfo_chars").text() === "200")
               assert(document.getElementById("service-info-list").text() === "Home Manage account Messages Help and contact")
 
               document.getElementById("submit").text() must be("Save and continue")
@@ -240,7 +241,6 @@ lazy implicit val messages: MessagesImpl = MessagesImpl(Lang("en-GB"), messagesA
               val document = Jsoup.parse(contentAsString(result))
 
               document.getElementById("supportingInfo").toString must include("supportingInfoTextAreaData")
-
               document.getElementById("submit").text() must be("Save and continue")
           }
         }

--- a/test/forms/PeriodDatesLiableFormSpec.scala
+++ b/test/forms/PeriodDatesLiableFormSpec.scala
@@ -30,6 +30,29 @@ class PeriodDatesLiableFormSpec extends PlaySpec with MustMatchers with GuiceOne
 
   "periodDatesLiableForm" must {
     "fail validation" when {
+
+      "empty start date and end date fields are entered" in {
+
+        val inputDate = Map("startDate.day" -> "",
+          "startDate.month" -> "",
+          "startDate.year" -> "",
+          "endDate.day" -> "",
+          "endDate.month" -> "",
+          "endDate.year" -> "")
+
+        PropertyDetailsForms.periodDatesLiableForm.bind(inputDate).fold(
+          hasErrors => {
+            hasErrors.errors.length mustBe 2
+            messages(hasErrors.errors.head.message) mustBe messages("ated.property-details-period.datesLiable.startDate.error.empty")
+            messages(hasErrors.errors.last.message) mustBe messages("ated.property-details-period.datesLiable.endDate.error.empty")
+
+          },
+          _ => {
+            fail("There is a problem")
+          }
+        )
+      }
+
       "start date and end date fields not entered correctly" in {
 
         val inputDate = Map("startDate.day" -> "13",


### PR DESCRIPTION
DL-3191

**Maintenance** 

Adding tests to cover some error validation that was being done in ATs repo (largely for Further Returns feature)

Included tests for error message key validation in PeriodDatesLiableFormSpec as it shared similar error messages and was missing these error validations

Added check for existence of supportingInfo_chars on Supporting Info view

## Checklist

*Reviewee* (Replace with your name)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date