### PR TITLE
Dl 5394

### DIFF
--- a/app/views/formBundleReturn.scala.html
+++ b/app/views/formBundleReturn.scala.html
@@ -299,12 +299,12 @@
   </div>
 
     <div class="form-group">
-      <p id="return-charge-text">
+      <div id="return-charge-text">
         @messages("ated.form-bundle.view.return.ated.charge")
-      <span class="heading-xlarge form group" id="return-charge">
-        @formattedPounds(formBundleReturnObj.liabilityAmount)
-      </span>
-      </p>
+        <span class="heading-xlarge form group" id="return-charge">
+          @formattedPounds(formBundleReturnObj.liabilityAmount)
+        </span>
+      </div>
     </div>
 
     <div class="form-group">

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ import sbt._
 resolvers += Resolver.bintrayIvyRepo("hmrc", "sbt-plugin-releases")
 resolvers += Resolver.bintrayRepo("hmrc", "releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.13.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.15.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
 


### PR DESCRIPTION
DL-5394

Address specific issue where user was taking a browser screen shot of an already submitted liability return which was not including the chargeable amount. 

This is a quick fix as the users should be using the appropriate printer friendly versions available at the time of creation or further amendment in order to get a better constructed record of their submission.

## Checklist

*Reviewee* (Replace with your name)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [x]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date