### PR TITLE
 DL-5505 Updating link content to improve accessibility

### DIFF
--- a/conf/messages
+++ b/conf/messages
@@ -819,7 +819,7 @@ ated.property-details-period-error.general.taxAvoidancePromoterReference = There
 ated.property-details-period.supportingInfo.title = Do you have any supporting information to add? (optional)
 ated.property-details-period.supportingInfo.header = Do you have any supporting information to add? (optional)
 ated.property-details-period.supportingInfo = Supporting information (optional)
-ated.property-details-period.supportingInfo.hint = <a href="https://www.gov.uk/government/publications/stld-annual-tax-on-enveloped-dwellings-ated/annual-tax-on-enveloped-dwellings-returns-guidance#sec5" target="_blank">How to send additional information about your return (opens in new tab)</a>.
+ated.property-details-period.supportingInfo.hint = <a href="https://www.gov.uk/government/publications/stld-annual-tax-on-enveloped-dwellings-ated/annual-tax-on-enveloped-dwellings-returns-guidance#sec5" target="_blank">How to send additional information about your return (opens in new tab)</a>
 ated.property-details-period-error.supportingInfo = You cannot enter more than 200 characters in supporting information
 ated.property-details-period-error.supportingInfo.invalid = You cannot enter special characters. For example £, or @.
 ated.property-details-period-error.general.supportingInfo = There is a problem with your supporting information

--- a/conf/messages
+++ b/conf/messages
@@ -819,7 +819,7 @@ ated.property-details-period-error.general.taxAvoidancePromoterReference = There
 ated.property-details-period.supportingInfo.title = Do you have any supporting information to add? (optional)
 ated.property-details-period.supportingInfo.header = Do you have any supporting information to add? (optional)
 ated.property-details-period.supportingInfo = Supporting information (optional)
-ated.property-details-period.supportingInfo.hint = See the <a href="https://www.gov.uk/government/publications/stld-annual-tax-on-enveloped-dwellings-ated/annual-tax-on-enveloped-dwellings-returns-guidance#sec5" target="_blank">guidance for more information</a>.
+ated.property-details-period.supportingInfo.hint = <a href="https://www.gov.uk/government/publications/stld-annual-tax-on-enveloped-dwellings-ated/annual-tax-on-enveloped-dwellings-returns-guidance#sec5" target="_blank">How to send additional information about your return (opens in new tab)</a>.
 ated.property-details-period-error.supportingInfo = You cannot enter more than 200 characters in supporting information
 ated.property-details-period-error.supportingInfo.invalid = You cannot enter special characters. For example £, or @.
 ated.property-details-period-error.general.supportingInfo = There is a problem with your supporting information


### PR DESCRIPTION
DL-5505 ATED Accessibility: Non-descriptive links 1 

test pass without any update

Link content updated to provide more context to fix accessibility A WCAG 2.1 fail.

## Before
![Screenshot 2021-11-02 at 15 08 20](https://user-images.githubusercontent.com/1692222/139875939-a2cb6021-029d-4c2e-aa3a-7dbf48a6fabe.png)

## After
![Screenshot 2021-11-02 at 15 07 52](https://user-images.githubusercontent.com/1692222/139875971-91440a0c-b651-4a18-a976-7e47de35f514.png)
