### PR TITLE
Remove unnecessary visually hidden content from table

### DIFF
--- a/app/views/prevPeriodsSummary.scala.html
+++ b/app/views/prevPeriodsSummary.scala.html
@@ -78,11 +78,11 @@
         <p class="govuk-body">@messages("ated.prev-period-summary.chareablePeriods.text")</p>
 
         <table class="govuk-table">
+            <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden">@messages("ated.summary-return.table.caption")</caption>
             <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
                     <th scope="col" class="govuk-table__header">
-                        <span class="govuk-visually-hidden">@messages("ated.summary-return.table.screen-reader.headings-help")</span>
-                        @messages("ated.prev-period-summary-th.period")</th>
+                    @messages("ated.prev-period-summary-th.period")</th>
                     <th id="charge-title" scope="col" class="govuk-table__header govuk-table__header--numeric">@messages("ated.prev-period-summary-th.chargeable")</th>
                     <th id="relief-title" scope="col" class="govuk-table__header govuk-table__header--numeric">@messages("ated.prev-period-summary-th.reliefs")</th>
                     <th id="draft-title" scope="col" class="govuk-table__header govuk-table__header--numeric">@messages("ated.prev-period-summary-th.drafts")</th>
@@ -90,31 +90,25 @@
             </thead>
             <tbody class="govuk-table__body">
                 @summaryReturnsWithDrafts.returnsOtherTaxYears.zipWithIndex.map { case (periodSummaryWithDraft, i) =>
-                <tr class="govuk-table__row">
-                    <td class="govuk-table__cell govuk-table__cell--text">
-                        <a class="govuk-link" href="@controllers.routes.PeriodSummaryController.view(periodSummaryWithDraft.periodKey)"
-                        id="view-change-@i">
-                                Returns for @periodSummaryWithDraft.periodKey to @(periodSummaryWithDraft.periodKey.toInt + 1)
-                            <span class="govuk-visually-hidden">
-                               @messages("ated.prev-period-summary-screen-reader")
-                            </span>
-                        </a>
-                    </td>
-                    <td id="charge-number-@i" class="govuk-table__cell govuk-table__cell--numeric">
-                        <span class="govuk-visually-hidden">@messages("ated.summary-return.table.screen-reader.number-of") @messages("ated.prev-period-summary-th.chargeable")</span>
-                        @periodSummaryWithDraft.submittedReturns.fold(0)(a => a.currentLiabilityReturns.size + a.oldLiabilityReturns.size)
-                    </td>
-                    <td id="reliefs-number-@i" class="govuk-table__cell govuk-table__cell--numeric">
-                        <span class="govuk-visually-hidden">@messages("ated.summary-return.table.screen-reader.number-of") @messages("ated.prev-period-summary-th.reliefs")</span>
-                        @periodSummaryWithDraft.submittedReturns.fold(0)(a => a.reliefReturns.size)
-                    </td>
-                    <td id="draft-number-@i" class="govuk-table__cell govuk-table__cell--numeric">
-                        <span class="govuk-visually-hidden">@messages("ated.summary-return.table.screen-reader.number-of") @messages("ated.prev-period-summary-th.drafts")</span>
-                        @periodSummaryWithDraft.draftReturns.size
-                    </td>
-                </tr>
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__cell govuk-table__cell--text govuk-!-font-weight-regular">
+                            <a class="govuk-link" href="@controllers.routes.PeriodSummaryController.view(periodSummaryWithDraft.periodKey)"
+                            id="view-change-@i">
+                                    Returns for @periodSummaryWithDraft.periodKey to @(periodSummaryWithDraft.periodKey.toInt + 1)
+                            </a>
+                        </th scope="row">
+                        <td id="charge-number-@i" class="govuk-table__cell govuk-table__cell--numeric">
+                            @periodSummaryWithDraft.submittedReturns.fold(0)(a => a.currentLiabilityReturns.size + a.oldLiabilityReturns.size)
+                        </td>
+                        <td id="reliefs-number-@i" class="govuk-table__cell govuk-table__cell--numeric">
+                            @periodSummaryWithDraft.submittedReturns.fold(0)(a => a.reliefReturns.size)
+                        </td>
+                        <td id="draft-number-@i" class="govuk-table__cell govuk-table__cell--numeric">
+                            @periodSummaryWithDraft.draftReturns.size
+                        </td>
+                    </tr>
+                }
             </tbody>
-            }
         </table>
     }
     <p class="govuk-body">@messages("ated.prev-period-summary.createRuturn.text") @(taxYearStartingYear - 1) to @(taxYearStartingYear) or earlier.</p>

--- a/conf/messages
+++ b/conf/messages
@@ -321,7 +321,6 @@ ated.avoidance-scheme-error.general.numeric-error.equityReleaseSchemePromoter = 
 ated.prev-period-summary.title = Your previous returns
 ated.prev-period-summary.header = Your previous returns
 ated.prev-period-summary.headerNoReturns = Create an ATED return for
-ated.prev-period-summary-screen-reader = the period
 ated.prev-period-summary-th.period = Period
 ated.prev-period-summary-th.chargeable = Chargeable
 ated.prev-period-summary-th.reliefs = Relief
@@ -352,8 +351,7 @@ ated.summary-return.company-details.link = View your ATED details
 ated.summary-return.return-type.error = Select an option for type of return
 ated.account-summary.create-return.link = Create a new return
 ated.account-summary.create-return-other.link = Create, view or change returns for other years
-ated.summary-return.table.screen-reader.headings-help = You are on the ATED table, column headings are as follows
-ated.summary-return.table.screen-reader.number-of = Number of
+ated.summary-return.table.caption = Your previous ATED returns
 
 ##### RETURN TYPE
 


### PR DESCRIPTION
This additional content, presumably designed to improve the accessibility of the table, actually made it more confusing to navigate. Removing it and adding a visually hidden caption has vastly improved this for screen reader users.

Unused message keys removed.

Unit test ran and unaffected.
