### PR TITLE
DL - 18377: ATED: Account Details in Disposed Property Flow Should Be Trimmed

### DIFF
--- a/app/forms/BankDetailForms.scala
+++ b/app/forms/BankDetailForms.scala
@@ -141,7 +141,7 @@ object BankDetailForms {
         case None | Some("") =>
           Seq(Some(FormError("accountNumber", "ated.bank-details.error-key.accountNumber.empty")))
 
-        case Some(acc) if !acc.matches("^\\d{6,8}$") =>
+        case Some(acc) if acc.length > 18 =>
           Seq(Some(FormError("accountNumber", "ated.bank-details.error-key.accountNumber.max-len")))
 
         case Some(acc) if !acc.forall(_.isDigit) =>

--- a/app/forms/BankDetailForms.scala
+++ b/app/forms/BankDetailForms.scala
@@ -17,7 +17,7 @@
 package forms
 
 import models._
-import play.api.data.Forms._
+import play.api.data.Forms.{text, _}
 import play.api.data.format.Formatter
 import play.api.data.validation.{Constraint, Invalid, Valid, ValidationError}
 import play.api.data.{Form, FormError, Mapping}
@@ -32,6 +32,23 @@ object BankDetailForms {
   private val sortCodeTuple: Mapping[Option[SortCode]] = sortCodeTupleOpt
 
   private def sanitiseSortCode(sortCode: String): String = sortCode.replaceAll("""[\s\-–]""", "")
+
+  private def sanitiseAccountNumber(accountNumber: String): String = accountNumber.replaceAll("""\\s+""", "").trim
+
+  private def accountNumberClean: Mapping[Option[String]] = {
+
+    optional(text)
+      .transform[Option[String]](
+      {
+        case Some(text) => Some(sanitiseAccountNumber(text))
+        case _ => None
+      },
+      {
+        case Some(a) => Some(a)
+        case _ => None
+      }
+    )
+  }
 
   private def sortCodeTupleOpt: Mapping[Option[SortCode]] = {
 
@@ -93,7 +110,7 @@ object BankDetailForms {
   val bankDetailsForm: Form[BankDetails] = Form(mapping(
     "hasUKBankAccount" -> optional(boolean),
     "accountName" -> optional(text).verifying(accountNameConstraint),
-    "accountNumber" -> optional(text),
+    "accountNumber" -> accountNumberClean,
     "sortCode" -> sortCodeTuple,
     "buildingNumber" -> optional(text),
     "bicSwiftCode" -> optional(of[BicSwiftCode]),
@@ -117,7 +134,7 @@ object BankDetailForms {
     }
 
     def validateAccountNumber: Seq[Option[FormError]] = {
-      val accountNumber = bankDetails.data.get("accountNumber").map(_.trim)
+      val accountNumber = bankDetails.data.get("accountNumber").map(x => sanitiseAccountNumber(x))
       if (accountNumber.getOrElse("").isEmpty) {
         Seq(Some(FormError("accountNumber", "ated.bank-details.error-key.accountNumber.empty")))
       }

--- a/app/forms/BankDetailForms.scala
+++ b/app/forms/BankDetailForms.scala
@@ -135,17 +135,21 @@ object BankDetailForms {
 
     def validateAccountNumber: Seq[Option[FormError]] = {
       val accountNumber = bankDetails.data.get("accountNumber").map(x => sanitiseAccountNumber(x))
-      if (accountNumber.getOrElse("").isEmpty) {
-        Seq(Some(FormError("accountNumber", "ated.bank-details.error-key.accountNumber.empty")))
-      }
-      else if (accountNumber.nonEmpty && accountNumber.getOrElse("").length > 18) {
-        Seq(Some(FormError("accountNumber", "ated.bank-details.error-key.accountNumber.max-len")))
-      }
-      else if (accountNumber.nonEmpty && !accountNumber.get.matches("""^[0-9]+$""")) {
-        Seq(Some(FormError("accountNumber", "ated.bank-details.error-key.accountNumber.invalid")))
-      }
-      else Seq()
-    }
+
+      accountNumber match {
+
+        case None | Some("") =>
+          Seq(Some(FormError("accountNumber", "ated.bank-details.error-key.accountNumber.empty")))
+
+        case Some(acc) if !acc.matches("^\\d{6,8}$") =>
+          Seq(Some(FormError("accountNumber", "ated.bank-details.error-key.accountNumber.max-len")))
+
+        case Some(acc) if !acc.forall(_.isDigit) =>
+          Seq(Some(FormError("accountNumber", "ated.bank-details.error-key.accountNumber.invalid")))
+
+        case _ =>
+          Seq()
+      }}
 
     def validateSortCode: Seq[Option[FormError]] = {
       val sortCode = bankDetails.data.get("sortCode").map(x => sanitiseSortCode(x))

--- a/app/forms/BankDetailForms.scala
+++ b/app/forms/BankDetailForms.scala
@@ -33,7 +33,7 @@ object BankDetailForms {
 
   private def sanitiseSortCode(sortCode: String): String = sortCode.replaceAll("""[\s\-–]""", "")
 
-  private def sanitiseAccountNumber(accountNumber: String): String = accountNumber.replaceAll("""\\s+""", "").trim
+  private def sanitiseAccountNumber(accountNumber: String): String = accountNumber.trim
 
   private def accountNumberClean: Mapping[Option[String]] = {
 

--- a/test/forms/BankDetailFormsSpec.scala
+++ b/test/forms/BankDetailFormsSpec.scala
@@ -183,6 +183,35 @@ class BankDetailFormsSpec extends PlaySpec with GuiceOneServerPerSuite {
         )
       }
 
+      "supplied with AN with blank spaces at end for uk accounts" in {
+        BankDetailForms.validateBankDetails("", bankDetailsForm.bind(validUkDataWithSpaceAtEndAN)).fold(
+          formWithErrors => {
+            fail(s"form should not have errors. Errors: ${formWithErrors.errors}")
+
+          },
+          success => {
+            success.accountName mustBe Some("Account Name")
+            success.accountNumber mustBe Some("12345678")
+            success.sortCode mustBe Some(SortCode("11","22","33"))
+          }
+        )
+      }
+
+      "supplied with AN with blank spaces at start for uk accounts" in {
+        BankDetailForms.validateBankDetails("", bankDetailsForm.bind(validUkDataWithSpaceAtStartAN)).fold(
+          formWithErrors => {
+            fail(s"form should not have errors. Errors: ${formWithErrors.errors}")
+
+          },
+          success => {
+            success.accountName mustBe Some("Account Name")
+            success.accountNumber mustBe Some("12345678")
+            success.sortCode mustBe Some(SortCode("11","22","33"))
+          }
+        )
+      }
+
+
       "supplied with sort code with blank spaces at end for uk accounts" in {
         BankDetailForms.validateBankDetails("", bankDetailsForm.bind(validUkDataWithSpaceAtEndOfSortCode)).fold(
           formWithErrors => {
@@ -238,37 +267,6 @@ class BankDetailFormsSpec extends PlaySpec with GuiceOneServerPerSuite {
           }
         )
       }
-
-
-      "supplied with AN with blank spaces at end for uk accounts" in {
-        BankDetailForms.validateBankDetails("", bankDetailsForm.bind(validUkDataWithSpaceAtEndAN)).fold(
-          formWithErrors => {
-            fail(s"form should not have errors. Errors: ${formWithErrors.errors}")
-
-          },
-          success => {
-            success.accountName mustBe Some("Account Name")
-            success.accountNumber mustBe Some("12345678")
-            success.sortCode mustBe Some(SortCode("11","22","33"))
-          }
-        )
-      }
-
-      "supplied with AN with blank spaces at start for uk accounts" in {
-        BankDetailForms.validateBankDetails("", bankDetailsForm.bind(validUkDataWithSpaceAtStartAN)).fold(
-          formWithErrors => {
-            fail(s"form should not have errors. Errors: ${formWithErrors.errors}")
-
-          },
-          success => {
-            success.accountName mustBe Some("Account Name")
-            success.accountNumber mustBe Some("12345678")
-            success.sortCode mustBe Some(SortCode("11","22","33"))
-          }
-        )
-      }
-
-
 
       "supplied with valid data for non uk accounts" in {
         BankDetailForms.validateBankDetails("", bankDetailsForm.bind(validNonUkData)).fold(

--- a/test/forms/BankDetailFormsSpec.scala
+++ b/test/forms/BankDetailFormsSpec.scala
@@ -66,6 +66,14 @@ class BankDetailFormsSpec extends PlaySpec with GuiceOneServerPerSuite {
     "sortCode" -> "112233"
   )
 
+
+  val validAccountNumberWithSpaces: Map[String, String] = Map("hasUKBankAccount" -> "true",
+    "accountName" -> "Account Name",
+    "accountNumber" -> " 123 45678 ",
+    "sortCode" -> "112233"
+  )
+
+
   val validUkDataWithSpaceAtStartAN: Map[String, String] = Map("hasUKBankAccount" -> "true",
     "accountName" -> "Account Name",
     "accountNumber" -> "   12345678",
@@ -133,6 +141,20 @@ class BankDetailFormsSpec extends PlaySpec with GuiceOneServerPerSuite {
     "pass through validation" when {
       "supplied with valid data for uk accounts" in {
         BankDetailForms.validateBankDetails("", bankDetailsForm.bind(validUkData)).fold(
+          formWithErrors => {
+            fail(s"form should not have errors. Errors: ${formWithErrors.errors}")
+
+          },
+          success => {
+            success.accountName mustBe Some("Account Name")
+            success.accountNumber mustBe Some("12345678")
+            success.sortCode mustBe Some(SortCode("11","22","33"))
+          }
+        )
+      }
+
+      "supplied with valid data for uk accounts with spaces in account number" in {
+        BankDetailForms.validateBankDetails("", bankDetailsForm.bind(validAccountNumberWithSpaces)).fold(
           formWithErrors => {
             fail(s"form should not have errors. Errors: ${formWithErrors.errors}")
 

--- a/test/forms/BankDetailFormsSpec.scala
+++ b/test/forms/BankDetailFormsSpec.scala
@@ -156,13 +156,10 @@ class BankDetailFormsSpec extends PlaySpec with GuiceOneServerPerSuite {
       "supplied with valid data for uk accounts with spaces in account number" in {
         BankDetailForms.validateBankDetails("", bankDetailsForm.bind(validAccountNumberWithSpaces)).fold(
           formWithErrors => {
-            fail(s"form should not have errors. Errors: ${formWithErrors.errors}")
-
+            formWithErrors.errors.last.message mustBe "ated.bank-details.error-key.accountNumber.invalid"
           },
-          success => {
-            success.accountName mustBe Some("Account Name")
-            success.accountNumber mustBe Some("12345678")
-            success.sortCode mustBe Some(SortCode("11","22","33"))
+          _ => {
+            fail("Form should give an error")
           }
         )
       }

--- a/test/forms/BankDetailFormsSpec.scala
+++ b/test/forms/BankDetailFormsSpec.scala
@@ -73,6 +73,12 @@ class BankDetailFormsSpec extends PlaySpec with GuiceOneServerPerSuite {
     "sortCode" -> "112233"
   )
 
+  val validAccountNumberWithSpacesBothLeadingAndTrailing: Map[String, String] = Map("hasUKBankAccount" -> "true",
+    "accountName" -> "Account Name",
+    "accountNumber" -> " 12345678 ",
+    "sortCode" -> "112233"
+  )
+
 
   val validUkDataWithSpaceAtStartAN: Map[String, String] = Map("hasUKBankAccount" -> "true",
     "accountName" -> "Account Name",
@@ -144,6 +150,19 @@ class BankDetailFormsSpec extends PlaySpec with GuiceOneServerPerSuite {
           formWithErrors => {
             fail(s"form should not have errors. Errors: ${formWithErrors.errors}")
 
+          },
+          success => {
+            success.accountName mustBe Some("Account Name")
+            success.accountNumber mustBe Some("12345678")
+            success.sortCode mustBe Some(SortCode("11","22","33"))
+          }
+        )
+      }
+
+      "supplied with valid data for uk accounts with Leading and trailing spaces in account number" in {
+        BankDetailForms.validateBankDetails("", bankDetailsForm.bind(validAccountNumberWithSpacesBothLeadingAndTrailing)).fold(
+          formWithErrors => {
+            formWithErrors.errors.last.message mustBe "ated.bank-details.error-key.accountNumber.invalid"
           },
           success => {
             success.accountName mustBe Some("Account Name")

--- a/test/forms/BankDetailFormsSpec.scala
+++ b/test/forms/BankDetailFormsSpec.scala
@@ -59,6 +59,19 @@ class BankDetailFormsSpec extends PlaySpec with GuiceOneServerPerSuite {
     "sortCode" -> "11-22 33"
   )
 
+
+  val validUkDataWithSpaceAtEndAN: Map[String, String] = Map("hasUKBankAccount" -> "true",
+    "accountName" -> "Account Name",
+    "accountNumber" -> "12345678   ",
+    "sortCode" -> "112233"
+  )
+
+  val validUkDataWithSpaceAtStartAN: Map[String, String] = Map("hasUKBankAccount" -> "true",
+    "accountName" -> "Account Name",
+    "accountNumber" -> "   12345678",
+    "sortCode" -> "112233"
+  )
+
   val nonValidUkData: Map[String, String] = Map("hasUKBankAccount" -> "true",
     "accountName" -> "Account Name",
     "accountNumber" -> "aaaaaa",
@@ -187,6 +200,36 @@ class BankDetailFormsSpec extends PlaySpec with GuiceOneServerPerSuite {
           }
         )
       }
+
+
+      "supplied with AN with blank spaces at end for uk accounts" in {
+        BankDetailForms.validateBankDetails("", bankDetailsForm.bind(validUkDataWithSpaceAtEndAN)).fold(
+          formWithErrors => {
+            fail(s"form should not have errors. Errors: ${formWithErrors.errors}")
+
+          },
+          success => {
+            success.accountName mustBe Some("Account Name")
+            success.accountNumber mustBe Some("12345678")
+            success.sortCode mustBe Some(SortCode("11","22","33"))
+          }
+        )
+      }
+
+      "supplied with AN with blank spaces at start for uk accounts" in {
+        BankDetailForms.validateBankDetails("", bankDetailsForm.bind(validUkDataWithSpaceAtStartAN)).fold(
+          formWithErrors => {
+            fail(s"form should not have errors. Errors: ${formWithErrors.errors}")
+
+          },
+          success => {
+            success.accountName mustBe Some("Account Name")
+            success.accountNumber mustBe Some("12345678")
+            success.sortCode mustBe Some(SortCode("11","22","33"))
+          }
+        )
+      }
+
 
 
       "supplied with valid data for non uk accounts" in {


### PR DESCRIPTION
1. Trim Leading and trailing spaces for Account number in Bank Details. 
2. Added test cases for spaces in account number.