### PR TITLE
Dl 18394 - Prevent sending the PPOB in subscritpion update requests

### DIFF
--- a/app/controllers/editLiability/DisposeLiabilityHasUkBankAccountController.scala
+++ b/app/controllers/editLiability/DisposeLiabilityHasUkBankAccountController.scala
@@ -58,7 +58,7 @@ class DisposeLiabilityHasUkBankAccountController @Inject()(mcc: MessagesControll
                 oldFormBundleNo,
                 serviceInfoContent,
                 Some(controllers.editLiability.routes.DisposeLiabilityHasBankDetailsController.view(oldFormBundleNo).url))))
-            case None => Future.successful(Redirect(controllers.routes.AccountSummaryController.view))
+            case None => Future.successful(Redirect(controllers.routes.AccountSummaryController.view()))
           }
         }
       }
@@ -79,7 +79,7 @@ class DisposeLiabilityHasUkBankAccountController @Inject()(mcc: MessagesControll
                   serviceInfoContent,
                   Some(controllers.editLiability.routes.DisposeLiabilitySummaryController.view(oldFormBundleNo).url)))
               }
-            case None => Future.successful(Redirect(controllers.routes.AccountSummaryController.view))
+            case None => Future.successful(Redirect(controllers.routes.AccountSummaryController.view()))
           }
         }
       }

--- a/app/controllers/editLiability/DisposeLiabilityNonUkBankDetailsController.scala
+++ b/app/controllers/editLiability/DisposeLiabilityNonUkBankDetailsController.scala
@@ -57,7 +57,7 @@ class DisposeLiabilityNonUkBankDetailsController @Inject()(mcc: MessagesControll
                 (bankDetailsForm.fill(bankDetails), oldFormBundleNo, serviceInfoContent, backLink)
                 (authContext, implicitly, request, implicitly))
               }
-            case None => Future.successful(Redirect(controllers.routes.AccountSummaryController.view))
+            case None => Future.successful(Redirect(controllers.routes.AccountSummaryController.view()))
           }
         }
       }
@@ -75,7 +75,7 @@ class DisposeLiabilityNonUkBankDetailsController @Inject()(mcc: MessagesControll
                 val bankDetails = x.bankDetails.flatMap(_.bankDetails).fold(BankDetails())(a => a)
                 Ok(template(bankDetailsForm.fill(bankDetails), oldFormBundleNo, serviceInfoContent, backLink))
               }
-            case None => Future.successful(Redirect(controllers.routes.AccountSummaryController.view))
+            case None => Future.successful(Redirect(controllers.routes.AccountSummaryController.view()))
           }
         }
       }

--- a/app/controllers/editLiability/HasUkBankAccountController.scala
+++ b/app/controllers/editLiability/HasUkBankAccountController.scala
@@ -61,7 +61,7 @@ class HasUkBankAccountController @Inject()(mcc: MessagesControllerComponents,
                   serviceInfoContent,
                   backLink))
               }
-            case None => Future.successful(Redirect(controllers.routes.AccountSummaryController.view))
+            case None => Future.successful(Redirect(controllers.routes.AccountSummaryController.view()))
           }
         }
       }
@@ -85,7 +85,7 @@ class HasUkBankAccountController @Inject()(mcc: MessagesControllerComponents,
                   serviceInfoContent,
                   AtedUtils.getSummaryBackLink(oldFormBundleNo, AtedUtils.getEditSubmittedMode(propertyDetails))))
               }
-            case None => Future.successful(Redirect(controllers.routes.AccountSummaryController.view))
+            case None => Future.successful(Redirect(controllers.routes.AccountSummaryController.view()))
           }
         }
       }

--- a/app/controllers/editLiability/UkBankDetailsController.scala
+++ b/app/controllers/editLiability/UkBankDetailsController.scala
@@ -58,7 +58,7 @@ class UkBankDetailsController @Inject()(mcc: MessagesControllerComponents,
                   serviceInfoContent,
                   backLink))
               }
-            case None => Future.successful(Redirect(controllers.routes.AccountSummaryController.view))
+            case None => Future.successful(Redirect(controllers.routes.AccountSummaryController.view()))
           }
         }
       }
@@ -77,7 +77,7 @@ class UkBankDetailsController @Inject()(mcc: MessagesControllerComponents,
                   serviceInfoContent,
                   AtedUtils.getSummaryBackLink(oldFormBundleNo, AtedUtils.getEditSubmittedMode(x))))
               }
-            case None => Future.successful(Redirect(controllers.routes.AccountSummaryController.view))
+            case None => Future.successful(Redirect(controllers.routes.AccountSummaryController.view()))
           }
         }
       }

--- a/app/services/SubscriptionDataAdapterService.scala
+++ b/app/services/SubscriptionDataAdapterService.scala
@@ -82,20 +82,18 @@ class SubscriptionDataAdapterService @Inject()(atedConnector: AtedConnector)(imp
                                                     name2 = Some(editedContactDetails.lastName),
                                                     addressDetails = editedCorrespondenceDetails,
                                                     contactDetails = editedContactDetail)
-      val filteredAddresses = oldData.address.filterNot(_.addressDetails.addressType == AtedConstants.AddressTypeCorrespondence)
       val emailConsent = oldData.emailConsent.getOrElse(false)
       new UpdateSubscriptionDataRequest(emailConsent = emailConsent, changeIndicators = ChangeIndicators(nameChanged = true, contactDetailsChanged = true),
-        address = filteredAddresses :+ updatedAddress)
+        address = Seq(updatedAddress))
     }
   }
 
   def createUpdateCorrespondenceAddressRequest(oldData: SubscriptionData, updatedAddressDetails: AddressDetails): Option[UpdateSubscriptionDataRequest] = {
     getCorrespondenceAddress(Some(oldData)).map { foundCorrespondence =>
       val updatedAddress = foundCorrespondence.copy(addressDetails = updatedAddressDetails)
-      val filteredAddresses = oldData.address.filterNot(_.addressDetails.addressType == AtedConstants.AddressTypeCorrespondence)
       val emailConsent = oldData.emailConsent.getOrElse(false)
       new UpdateSubscriptionDataRequest(emailConsent = emailConsent, changeIndicators = ChangeIndicators(correspondenceChanged = true), address =
-        filteredAddresses :+ updatedAddress)
+        Seq(updatedAddress))
     }
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ import uk.gov.hmrc.versioning.SbtGitVersioning.autoImport.majorVersion
 val appName = "ated-frontend"
 
 ThisBuild / majorVersion := 3
-ThisBuild / scalaVersion := "2.13.17"
+ThisBuild / scalaVersion := "2.13.18"
 
 lazy val appDependencies: Seq[ModuleID] = AppDependencies()
 lazy val plugins: Seq[Plugins] = Seq(play.sbt.PlayScala)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -19,7 +19,7 @@ import play.sbt.PlayImport.*
 
 object AppDependencies {
 
-  val bootstrapVersion = "10.5.0"
+  val bootstrapVersion = "10.7.0"
 
   val compile: Seq[ModuleID] = Seq(
     ws,
@@ -27,15 +27,14 @@ object AppDependencies {
     "uk.gov.hmrc"       %% "play-partials-play-30"       % "10.2.0",
     "uk.gov.hmrc"       %% "domain-play-30"              % "11.0.0",
     "uk.gov.hmrc"       %% "http-caching-client-play-30" % "12.2.0",
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"  % "12.29.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"  % "12.32.0",
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"          % "2.12.0",
     "org.jsoup"          % "jsoup"                       % "1.22.1"
   )
 
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"       %% "bootstrap-test-play-30"  % bootstrapVersion % Test,
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-30" % "2.12.0"         % Test,
-    "org.testcontainers" % "mongodb"                 % "1.21.1"         % Test
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-30" % "2.12.0"         % Test
   )
 
   val itDependencies: Seq[ModuleID] = Seq()

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,9 +21,9 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.6.0")
 
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.9")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.10")
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "2.4.0")
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "2.4.4")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0" exclude("org.scala-lang.modules", "scala-xml_2.12"))
 

--- a/test/controllers/AccountSummaryControllerSpec.scala
+++ b/test/controllers/AccountSummaryControllerSpec.scala
@@ -83,7 +83,7 @@ class AccountSummaryControllerSpec extends PlaySpec with GuiceOneServerPerSuite 
   }
 
   val periodKey2015: Int = 2015
-  val httpValue = 200
+  val httpSuccessValue = 200
 
   class Setup {
 
@@ -113,7 +113,7 @@ class AccountSummaryControllerSpec extends PlaySpec with GuiceOneServerPerSuite 
                                   clientBannerPartial: HtmlPartial = HtmlPartial.Success(Some("thepartial"), Html("")),
                                   clientMandateDetails: ClientMandateDetails = clientMandateDetails
                                 ): Unit = {
-      when(mockDataCacheService.clearCache()(ArgumentMatchers.any())).thenReturn(Future.successful(HttpResponse(httpValue, "")))
+      when(mockDataCacheService.clearCache()(ArgumentMatchers.any())).thenReturn(Future.successful(HttpResponse(httpSuccessValue, "")))
       when(mockSummaryReturnsService.generateCurrentTaxYearReturns(ArgumentMatchers.any())).thenReturn(Future.successful(Tuple3(Seq(), 0, false)))
       when(mockSummaryReturnsService.getSummaryReturns(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(returnsSummaryWithDraft))
       when(mockSubscriptionDataService.getCorrespondenceAddress(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(correspondence))
@@ -138,7 +138,7 @@ class AccountSummaryControllerSpec extends PlaySpec with GuiceOneServerPerSuite 
       val authMock = authResultDefault(AffinityGroup.Organisation, defaultEnrolmentSet)
       setAuthMocks(authMock)
 
-      when(mockDataCacheService.clearCache()(ArgumentMatchers.any())).thenReturn(Future.successful(HttpResponse(httpValue, "")))
+      when(mockDataCacheService.clearCache()(ArgumentMatchers.any())).thenReturn(Future.successful(HttpResponse(httpSuccessValue, "")))
       when(mockSummaryReturnsService.getSummaryReturns(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(returnsSummaryWithDraft))
       when(mockSubscriptionDataService.getCorrespondenceAddress(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(correspondence))
       when(mockSubscriptionDataService.getOrganisationName(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some(organisationName)))
@@ -160,7 +160,7 @@ class AccountSummaryControllerSpec extends PlaySpec with GuiceOneServerPerSuite 
       val authMock = authResultDefault(AffinityGroup.Organisation, invalidEnrolmentSet)
       setForbiddenAuthMocks(authMock)
 
-      when(mockDataCacheService.clearCache()(ArgumentMatchers.any())).thenReturn(Future.successful(HttpResponse(httpValue, "")))
+      when(mockDataCacheService.clearCache()(ArgumentMatchers.any())).thenReturn(Future.successful(HttpResponse(httpSuccessValue, "")))
       when(mockSummaryReturnsService.getSummaryReturns(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(returnsSummaryWithDraft))
       setupCommonMocks(returnsSummaryWithDraft, correspondence)
       when(mockSummaryReturnsService.generateCurrentTaxYearReturns(ArgumentMatchers.any())).thenReturn(Future.successful(Tuple3(Seq(), 0, false)))
@@ -173,7 +173,7 @@ class AccountSummaryControllerSpec extends PlaySpec with GuiceOneServerPerSuite 
       val userId = s"user-${UUID.randomUUID}"
       val authMock = authResultDefault(AffinityGroup.Agent, agentEnrolmentSet)
       setAuthMocks(authMock)
-      when(mockDataCacheService.clearCache()(ArgumentMatchers.any())).thenReturn(Future.successful(HttpResponse(httpValue, "")))
+      when(mockDataCacheService.clearCache()(ArgumentMatchers.any())).thenReturn(Future.successful(HttpResponse(httpSuccessValue, "")))
       when(mockSummaryReturnsService.getSummaryReturns(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(returnsSummaryWithDraft))
       when(mockSubscriptionDataService.getCorrespondenceAddress(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(correspondence))
       when(mockSubscriptionDataService.getOrganisationName(ArgumentMatchers.any(), ArgumentMatchers.any()))
@@ -281,10 +281,9 @@ class AccountSummaryControllerSpec extends PlaySpec with GuiceOneServerPerSuite 
 
       "show the agent info for authorised delegated user" in new Setup {
         val data: SummaryReturnsModel = SummaryReturnsModel(None, Seq())
-        val userId = s"user-${UUID.randomUUID}"
         val authMock: Enrolments ~ Some[AffinityGroup] ~ Some[String] = authResultDefault(AffinityGroup.Organisation, defaultEnrolmentSet)
         setAuthMocks(authMock)
-        when(mockDataCacheService.clearCache()(ArgumentMatchers.any())).thenReturn(Future.successful(HttpResponse(httpValue, "")))
+        when(mockDataCacheService.clearCache()(ArgumentMatchers.any())).thenReturn(Future.successful(HttpResponse(httpSuccessValue, "")))
         when(mockSummaryReturnsService.getSummaryReturns(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(data))
         when(mockSubscriptionDataService.getCorrespondenceAddress(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(None))
         when(mockDetailsService.cacheClientReference(ArgumentMatchers.any())(ArgumentMatchers.any()))

--- a/test/services/SubscriptionDataAdapterServiceSpec.scala
+++ b/test/services/SubscriptionDataAdapterServiceSpec.scala
@@ -291,6 +291,8 @@ class SubscriptionDataAdapterServiceSpec extends PlaySpec with MockitoSugar with
         val response: Option[UpdateSubscriptionDataRequest] = testSubscriptionDataAdapterService
           .createEditContactDetailsRequest(successResponse, updatedDetails)
         response.isDefined must be(true)
+        response.get.address.exists(addr => addr.addressDetails.addressType == AtedConstants.AddressTypeCorrespondence) must be(true)
+        response.get.address.size mustBe 1
         response.get.changeIndicators.contactDetailsChanged must be(true)
         response.get.changeIndicators.nameChanged must be(true)
         response.get.changeIndicators.correspondenceChanged must be(false)
@@ -303,6 +305,8 @@ class SubscriptionDataAdapterServiceSpec extends PlaySpec with MockitoSugar with
         val response: Option[UpdateSubscriptionDataRequest] = testSubscriptionDataAdapterService
           .createEditContactDetailsRequest(successResponse, updatedDetails)
         response.isDefined must be(true)
+        response.get.address.exists(addr => addr.addressDetails.addressType == AtedConstants.AddressTypeCorrespondence) must be(true)
+        response.get.address.size mustBe 1
         response.get.changeIndicators.contactDetailsChanged must be(true)
         response.get.changeIndicators.nameChanged must be(true)
         response.get.changeIndicators.correspondenceChanged must be(false)
@@ -315,6 +319,8 @@ class SubscriptionDataAdapterServiceSpec extends PlaySpec with MockitoSugar with
         val response: Option[UpdateSubscriptionDataRequest] = testSubscriptionDataAdapterService
           .createEditContactDetailsRequest(successResponse, updatedDetails)
         response.isDefined must be(true)
+        response.get.address.exists(addr => addr.addressDetails.addressType == AtedConstants.AddressTypeCorrespondence) must be(true)
+        response.get.address.size mustBe 1
         response.get.changeIndicators.contactDetailsChanged must be(true)
         response.get.changeIndicators.nameChanged must be(true)
         response.get.changeIndicators.correspondenceChanged must be(false)
@@ -333,10 +339,12 @@ class SubscriptionDataAdapterServiceSpec extends PlaySpec with MockitoSugar with
 
       "return Some if correspondence address is found" in new Setup {
         val successResponse: SubscriptionData = Json.parse(successJson).as[SubscriptionData]
-        val updatedDetails: AddressDetails = AddressDetails(addressType = "", addressLine1 = "", addressLine2 = "", countryCode = "GB")
+        val updatedDetails: AddressDetails = AddressDetails(addressType = "Correspondence", addressLine1 = "", addressLine2 = "", countryCode = "GB")
         val response: Option[UpdateSubscriptionDataRequest] = testSubscriptionDataAdapterService
           .createUpdateCorrespondenceAddressRequest(successResponse, updatedDetails)
         response.isDefined must be(true)
+        response.get.address.exists(addr => addr.addressDetails.addressType == AtedConstants.AddressTypeCorrespondence) must be(true)
+        response.get.address.size mustBe 1
         response.get.changeIndicators.contactDetailsChanged must be(false)
         response.get.changeIndicators.correspondenceChanged must be(true)
         response.get.changeIndicators.nameChanged must be(false)

--- a/test/views/html/AccountSummarySpec.scala
+++ b/test/views/html/AccountSummarySpec.scala
@@ -82,7 +82,6 @@ class AccountSummarySpec extends AtedViewSpec with MockAuthUtil with TestModels 
 
       "have correct deadline info text" in {
         val yearPassedToView = staticYearOf2025
-        val nextTaxYear = staticYearOf2025+1
         assert(doc.select(".govuk-body").get(0).text() contains
           s"The deadline for 2025 to 2026 returns and payments for all ATED-eligible properties that you own on 1 April $yearPassedToView is 30 April $yearPassedToView")
         assert(doc.select(".govuk-body").get(1).text() contains


### PR DESCRIPTION
This PR prevents the Permanent Place of Business (PPOB) to sent for requests to update subscription records. The PPOB is not needed, and can be excluded from the update communication.