### PR TITLE
DL19512 - address pattern pages updated with fieldset/legend

### DIFF
--- a/app/views/propertyDetails/propertyDetailsAddress.scala.html
+++ b/app/views/propertyDetails/propertyDetailsAddress.scala.html
@@ -63,63 +63,67 @@
         @govukErrorSummary(ErrorSummary().withFormErrorsAsText(propertyDetailsForm))
     }
 
-    <header>
-        <h2 class="govuk-caption-xl hmrc-caption-xl">
-            <span class="govuk-visually-hidden">@messages("ated.screen-reader.section")</span>
-            @messages(AtedUtils.getPropertyDetailsPreHeader(mode))
-        </h2>
-        <h1 class="govuk-heading-xl">
-            @if(fromConfirmAddressPage){
-                @messages("ated.property-details.editAddress")
-            } else {
-                @messages("ated.property-details.header")
-            }
-        </h1>
-    </header>
-
-    @if(fromConfirmAddressPage){
-        <p class="govuk-body">@messages("ated.property-details.p")</p>
-    }
-
     @formHelper(action = controllers.propertyDetails.routes.PropertyDetailsAddressController.save(id, periodKey, mode, fromConfirmAddressPage)) {
 
-        @govukInput(Input(
-            label = Label(
-              content = Text(messages("ated.addressProperty.line_1"))
-            ),
-            autocomplete = Some("address-line1")
-        ).withFormField(propertyDetailsForm("line_1")))
+        @govukFieldset(Fieldset(
+            describedBy = if(fromConfirmAddressPage) Some("confirm-address-hint") else None,
+            legend = Some(Legend(
+                content = HtmlContent(Html(s"""
+                    |<span class="govuk-caption-xl hmrc-caption-xl">
+                    |  <span class="govuk-visually-hidden">${messages("ated.screen-reader.section")}</span>
+                    |    ${messages(AtedUtils.getPropertyDetailsPreHeader(mode))}
+                    |</span>
+                    |${if(fromConfirmAddressPage) messages("ated.property-details.editAddress") else messages("ated.property-details.header")}
+                """.stripMargin)),
+                classes = "govuk-fieldset__legend--xl",
+                isPageHeading = true,
+            )),
+            html = HtmlFormat.fill(Seq(
+                if(fromConfirmAddressPage){
+                    Html(s"""<div class="govuk-hint" id="confirm-address-hint">${messages("ated.property-details.p")}</div>""")
+                } else {
+                    Html("")
+                },
 
-        @govukInput(Input(
-            label = Label(
-              content = Text(messages("ated.addressProperty.line_2"))
-            ),
-            autocomplete = Some("address-line2")
-        ).withFormField(propertyDetailsForm("line_2")))
+                govukInput(Input(
+                    label = Label(
+                    content = Text(messages("ated.addressProperty.line_1"))
+                    ),
+                    autocomplete = Some("address-line1")
+                ).withFormField(propertyDetailsForm("line_1"))),
 
-        @govukInput(Input(
-            label = Label(
-              content = Text(messages("ated.addressProperty.line_3"))
-            ),
-            classes = "govuk-!-width-two-thirds",
-            autocomplete = Some("address-line3")
-        ).withFormField(propertyDetailsForm("line_3")))
+                govukInput(Input(
+                    label = Label(
+                    content = Text(messages("ated.addressProperty.line_2"))
+                    ),
+                    autocomplete = Some("address-line2")
+                ).withFormField(propertyDetailsForm("line_2"))),
 
-        @govukInput(Input(
-            label = Label(
-              content = Text(messages("ated.addressProperty.line_4"))
-            ),
-        classes = "govuk-!-width-two-thirds",
-        autocomplete = Some("address-level2")
-        ).withFormField(propertyDetailsForm("line_4")))
+                govukInput(Input(
+                    label = Label(
+                    content = Text(messages("ated.addressProperty.line_3"))
+                    ),
+                    classes = "govuk-!-width-two-thirds",
+                    autocomplete = Some("address-line3")
+                ).withFormField(propertyDetailsForm("line_3"))),
 
-        @govukInput(Input(
-            label = Label(
-              content = Text(messages("ated.addressProperty.postcode"))
-            ),
-            classes = "govuk-input--width-10",
-            autocomplete = Some("postal-code")
-        ).withFormField(propertyDetailsForm("postcode")))
+                govukInput(Input(
+                    label = Label(
+                    content = Text(messages("ated.addressProperty.line_4"))
+                    ),
+                classes = "govuk-!-width-two-thirds",
+                autocomplete = Some("address-level2")
+                ).withFormField(propertyDetailsForm("line_4"))),
+
+                govukInput(Input(
+                    label = Label(
+                    content = Text(messages("ated.addressProperty.postcode"))
+                    ),
+                    classes = "govuk-input--width-10",
+                    autocomplete = Some("postal-code")
+                ).withFormField(propertyDetailsForm("postcode")))
+            ))
+        ))
 
         @if(!fromConfirmAddressPage) {
             <div class="govuk-form-group">

--- a/app/views/subcriptionData/correspondenceAddress.scala.html
+++ b/app/views/subcriptionData/correspondenceAddress.scala.html
@@ -56,36 +56,42 @@
     @if(correspondenceAddressForm.hasErrors) {
         @govukErrorSummary(ErrorSummary().withFormErrorsAsText(correspondenceAddressForm))
     }
-    <header>
-        <h2 class="govuk-caption-xl hmrc-caption-xl">
-            <span class="govuk-visually-hidden">@messages("ated.screen-reader.section")</span>
-            @messages("ated.correspondence-address.subheader")
-        </h2>
-        <h1 class="govuk-heading-xl">
-            @messages("ated.correspondence-address.header")
-        </h1>
-    </header>
   @formHelper(action = controllers.subscriptionData.routes.CorrespondenceAddressController.submit) {
 
-      @input(Input(inputType = "hidden").withFormField(correspondenceAddressForm("addressType")))
-      @input(Input(label = Label(content = Text(messages("ated.addressLine1"))),
-                   autocomplete = Some("address-line1")).withFormField(correspondenceAddressForm("addressLine1")))
-      @input(Input(label = Label(content = Text(messages("ated.addressLine2"))),
-                   autocomplete = Some("address-line2")).withFormField(correspondenceAddressForm("addressLine2")))
-      @input(Input(label = Label(content = Text(messages("ated.addressLine3"))),
-                   autocomplete = Some("address-line3"), classes = "govuk-!-width-two-thirds").withFormField(correspondenceAddressForm("addressLine3")))
-      @input(Input(label = Label(content = Text(messages("ated.addressLine4"))),
-                   autocomplete = Some("address-level2"), classes = "govuk-!-width-two-thirds").withFormField(correspondenceAddressForm("addressLine4")))
-      @select(Select(
-          label = Label(content = Text(messages("ated.country"))),
-          items = Seq(SelectItem(Some(""), "Select a country")) ++ listOfIsoCode.map {
-              case (code, country) => SelectItem(
-                  value = Some(code),
-                  text = country)
-          }
-      ).withFormField(correspondenceAddressForm("countryCode")))
-      @input(Input(label = Label(content = Text(messages("ated.postcode"))),
-      autocomplete = Some("postal-code"), classes = "govuk-input--width-10").withFormField(correspondenceAddressForm("postalCode")))
+    @fieldset(Fieldset(
+        legend = Some(Legend(
+            content = HtmlContent(Html(s"""
+                |<span class="govuk-caption-xl hmrc-caption-xl">
+                |  <span class="govuk-visually-hidden">${messages("ated.screen-reader.section")}</span>
+                |    ${messages("ated.correspondence-address.subheader")}
+                |</span>
+                |${messages("ated.correspondence-address.header")}
+            """.stripMargin)),
+            classes = "govuk-fieldset__legend--xl",
+            isPageHeading = true,
+        )),
+        html = HtmlFormat.fill(Seq(
+            input(Input(inputType = "hidden").withFormField(correspondenceAddressForm("addressType"))),
+            input(Input(label = Label(content = Text(messages("ated.addressLine1"))),
+                   autocomplete = Some("address-line1")).withFormField(correspondenceAddressForm("addressLine1"))),
+            input(Input(label = Label(content = Text(messages("ated.addressLine2"))),
+                   autocomplete = Some("address-line2")).withFormField(correspondenceAddressForm("addressLine2"))),
+            input(Input(label = Label(content = Text(messages("ated.addressLine3"))),
+                   autocomplete = Some("address-line3"), classes = "govuk-!-width-two-thirds").withFormField(correspondenceAddressForm("addressLine3"))),
+            input(Input(label = Label(content = Text(messages("ated.addressLine4"))),
+                   autocomplete = Some("address-level2"), classes = "govuk-!-width-two-thirds").withFormField(correspondenceAddressForm("addressLine4"))),
+            select(Select(
+                label = Label(content = Text(messages("ated.country"))),
+                items = Seq(SelectItem(Some(""), "Select a country")) ++ listOfIsoCode.map {
+                    case (code, country) => SelectItem(
+                        value = Some(code),
+                        text = country)
+                }
+                ).withFormField(correspondenceAddressForm("countryCode"))),
+            input(Input(label = Label(content = Text(messages("ated.postcode"))),
+                autocomplete = Some("postal-code"), classes = "govuk-input--width-10").withFormField(correspondenceAddressForm("postalCode")))
+        ))
+    ))
 
     @button(Button(content = Text(messages("ated.save-changes"))))
 

--- a/app/views/subcriptionData/editContactDetails.scala.html
+++ b/app/views/subcriptionData/editContactDetails.scala.html
@@ -19,7 +19,7 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
 @import views.ViewUtils.titleBuilder
 
-@this(newMain: newMain, formHelper: FormWithCSRF, input: GovukInput, button: GovukButton, govukBackLink: GovukBackLink, govukErrorSummary: GovukErrorSummary)
+@this(newMain: newMain, formHelper: FormWithCSRF, fieldset: GovukFieldset, input: GovukInput, button: GovukButton, govukBackLink: GovukBackLink, govukErrorSummary: GovukErrorSummary)
 @(editContactDetailsForm: Form[models.EditContactDetails], serviceInfoContent: Html = HtmlFormat.empty, backLink: Option[String])(implicit authContext: StandardAuthRetrievals, messages: Messages, request: Request[AnyContent], appConfig: ApplicationConfig)
 
 @backLinkHtml = {
@@ -37,30 +37,34 @@
         @govukErrorSummary(ErrorSummary().withFormErrorsAsText(editContactDetailsForm))
     }
 
-    <header>
-        <h2 class="govuk-caption-xl hmrc-caption-xl">
-            <span class="govuk-visually-hidden">@messages("ated.screen-reader.section")</span>
-            @messages("ated.contact-details-edit.subheader")
-        </h2>
-        <h1 class="govuk-heading-xl">
-            @messages("ated.contact-details.header")
-        </h1>
-    </header>
-
-    <p id="contact-details-subheader" class="govuk-body"> @messages("ated.contact-details.subheader")</p>
-
   @formHelper(action = controllers.subscriptionData.routes.EditContactDetailsController.submit) {
 
+    @fieldset(Fieldset(
+        describedBy = Some("edit-contact-hint"),
+        legend = Some(Legend(
+            content = HtmlContent(Html(s"""
+                |<span class="govuk-caption-xl hmrc-caption-xl">
+                |  <span class="govuk-visually-hidden">${messages("ated.screen-reader.section")}</span>
+                |    ${messages("ated.contact-details-edit.subheader")}
+                |</span>
+                |${messages("ated.contact-details.header")}
+            """.stripMargin)),
+            classes = "govuk-fieldset__legend--xl",
+            isPageHeading = true
+        )),
+        html = HtmlFormat.fill(Seq(
+            Html(s"""
+                |<div id="edit-contact-hint" class="govuk-hint">
+                |  ${messages("ated.contact-details.subheader")}
+                |</div>
+            """.stripMargin),
+            input(Input(label = Label(content = Text(messages("ated.contact-details.firstName"))), autocomplete = Some("given-name")).withFormField(editContactDetailsForm("firstName"))),
+            input(Input(label = Label(content = Text(messages("ated.contact-details.lastName"))), autocomplete = Some("family-name")).withFormField(editContactDetailsForm("lastName"))),
+            input(Input(label = Label(content = Text(messages("ated.contact-details.phoneNumber"))), autocomplete = Some("tel"), inputType = "tel").withFormField(editContactDetailsForm("phoneNumber")))
+        ))
+    ))
 
-      <div id="contact-address-form">
-
-        @input(Input(label = Label(content = Text(messages("ated.contact-details.firstName")))).withFormField(editContactDetailsForm("firstName")))
-        @input(Input(label = Label(content = Text(messages("ated.contact-details.lastName")))).withFormField(editContactDetailsForm("lastName")))
-        @input(Input(label = Label(content = Text(messages("ated.contact-details.phoneNumber"))), inputType = "tel").withFormField(editContactDetailsForm("phoneNumber")))
-
-      </div>
-
-      @button(Button(content = Text(messages("ated.save-changes"))))
+    @button(Button(content = Text(messages("ated.save-changes"))))
 
   }
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -27,7 +27,7 @@ object AppDependencies {
     "uk.gov.hmrc"       %% "play-partials-play-30"       % "10.2.0",
     "uk.gov.hmrc"       %% "domain-play-30"              % "11.0.0",
     "uk.gov.hmrc"       %% "http-caching-client-play-30" % "12.2.0",
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"  % "13.8.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"  % "13.9.0",
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"          % "2.12.0",
     "org.jsoup"          % "jsoup"                       % "1.22.2"
   )

--- a/test/controllers/propertyDetails/PropertyDetailsAddressControllerSpec.scala
+++ b/test/controllers/propertyDetails/PropertyDetailsAddressControllerSpec.scala
@@ -264,7 +264,7 @@ class PropertyDetailsAddressControllerSpec extends PlaySpec with GuiceOneServerP
               status(result) must be(OK)
               val document = Jsoup.parse(contentAsString(result))
               document.title() must be(TitleBuilder.buildTitle("Edit address"))
-              assert(document.getElementsByClass("govuk-heading-xl").text.contains("Edit address") === true)
+              assert(document.getElementsByClass("govuk-fieldset__legend--xl").text.contains("Edit address") === true)
               document.getElementsByClass("govuk-button").text must be("Save and continue")
               document.getElementById("line_1").attr("value") must be("addr1")
               document.getElementById("line_2").attr("value") must be("addr2")

--- a/test/views/html/subscriptionData/EditContactDetailsSpec.scala
+++ b/test/views/html/subscriptionData/EditContactDetailsSpec.scala
@@ -35,7 +35,7 @@ class EditContactDetailsSpec extends AtedViewSpec with MockitoSugar with MockAut
   }
 
   "have correct heading and caption" in {
-    doc.select("h2").text must include("This section is: Manage your ATED service")
+    doc.select("h1 .govuk-caption-xl").text must include("This section is: Manage your ATED service")
     doc.select("h1").text must include("Edit your ATED contact details")
   }
 
@@ -48,7 +48,7 @@ class EditContactDetailsSpec extends AtedViewSpec with MockitoSugar with MockAut
   "Edit contact details page" must {
 
     "display info text correctly" in {
-      doc must haveElementWithIdAndText(messages("ated.contact-details.subheader"), "contact-details-subheader")
+      doc must haveElementWithIdAndText(messages("ated.contact-details.subheader"), "edit-contact-hint")
     }
     "display first name label correctly" in {
       doc.getElementsByAttributeValue("for", "firstName").text mustBe messages("ated.contact-details.firstName")

--- a/test/views/propertyDetails/PropertyDetailsAddressSpec.scala
+++ b/test/views/propertyDetails/PropertyDetailsAddressSpec.scala
@@ -138,7 +138,7 @@ Feature("The user can view an empty property details page") {
       assert(document.getElementsByTag("h1").text() contains "Edit address")
 
       Then("The subheader should be - Create return")
-      assert(document.getElementsByTag("h2").text() contains "This section is: Create return")
+      assert(document.select("h1 .govuk-caption-xl").text() contains "This section is: Create return")
 
       Then("The address fields and action button are displayed")
       assert(document.getElementsByAttributeValue("for","line_1").text() === "Address line 1")


### PR DESCRIPTION
Updates address pages to use fieldset and legend. Address fields are all associated and make up one thing - the address, and all fields should be grouped together via a fieldset with a legend.

This PR updates address/contact details pages, grouping with a fieldset and legend.