### PR TITLE
DL-19606 - split words correctly in avoidance scheme hint text

### DIFF
--- a/conf/messages
+++ b/conf/messages
@@ -769,8 +769,8 @@ ated.property-details-period.taxAvoidancePromoterReference.error.empty = You mus
 
 ated.property-details-period.propertyDetailsReference.title = Enter your avoidance scheme details
 ated.property-details-period.propertyDetailsReference.header = Enter your avoidance scheme details
-ated.property-details-period.propertyDetailsReference.ref_hint = You can find your 8-digit avoidance reference number(SRN) on the AGG6 form fromyour scheme provider. For example, 12345678
-ated.property-details-period.propertyDetailsReference.promoter.hint = You can find your 8-digit promoter reference number(PRN) on the AGG6 form fromyour scheme provider. For example, 12345678
+ated.property-details-period.propertyDetailsReference.ref_hint = You can find your 8-digit avoidance reference number(SRN) on the AGG6 form from your scheme provider. For example, 12345678
+ated.property-details-period.propertyDetailsReference.promoter.hint = You can find your 8-digit promoter reference number(PRN) on the AGG6 form from your scheme provider. For example, 12345678
 
 
 


### PR DESCRIPTION
'from your' features no whitespace on the Avoidance Scheme page. This PR adds the whitespace.

<img width="811" height="391" alt="Screenshot 2026-06-26 at 16 26 58" src="https://github.com/user-attachments/assets/9a7930f0-0cee-41ca-89a3-3ae76e0bc253" />
